### PR TITLE
Allow custom working directory for Poetry bump version

### DIFF
--- a/actions/python-poetry-bump-version/README.md
+++ b/actions/python-poetry-bump-version/README.md
@@ -16,6 +16,7 @@ This action uses another composite action listed below:
 | release-type      |    ✅     |       -       | string  | Scope of the release, see the official [documentation of poetry](https://python-poetry.org/docs/cli/#version) for possible values  |
 | python-version    |    ❌     |     3.10      | number  | The python version for setting up poetry.                                                                                          |
 | poetry-version    |    ❌     |    1.1.12     | number  | The poetry version to be installed.                                                                                                |
+| working-directory |    ❌     |       .       | The root directory of the poetry project. |
 
 ## Output Parameters
 

--- a/actions/python-poetry-bump-version/action.yaml
+++ b/actions/python-poetry-bump-version/action.yaml
@@ -13,6 +13,10 @@ inputs:
     description: "The poetry version to be installed."
     required: false
     default: "1.1.12"
+  working-directory:
+    description: "The root directory of the poetry project."
+    required: false
+    default: "."
 
 outputs:
   release-tag:
@@ -30,6 +34,7 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         poetry-version: ${{ inputs.poetry-version }}
+        working-directory: ${{ inputs.working-directory }}
 
     # Update the pyproject.toml version. Versioning format for dev packages: X.Y.Z
     # For more information visit: https://www.python.org/dev/peps/pep-0440/#semantic-versioning
@@ -41,3 +46,4 @@ runs:
         poetry version ${{ inputs.release-type }}
         echo ::set-output name=newTag::$(poetry version -s)
       shell: bash
+      working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
In addition to #7, allow custom working directory also for Poetry bump version step and pass it down to Poetry setup action
In addition to #7, allow custom working directory also for Poetry bump version step and pass it down to Poetry setup action
