### PR TITLE
Abort Helm release if GitHub pages file doesn't exist

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -95,7 +95,7 @@ jobs:
           working-directory: ${{ inputs.charts-dir }}
 
       - name: Download previous Helm index
-        run: curl -O -f ${{ inputs.page-url }}/index.yaml
+        run: curl -O -L -f ${{ inputs.page-url }}/index.yaml
         if: ${{ inputs.skip-download == 'false' }}
         shell: bash
         working-directory: ${{ inputs.charts-dir }}
@@ -130,7 +130,7 @@ jobs:
         working-directory: ${{ inputs.charts-dir }}
 
       - name: Download packages
-        run: curl -O -f "${{ inputs.page-url }}/{${{ steps.packages.outputs.result }}}"
+        run: curl -O -L -f "${{ inputs.page-url }}/{${{ steps.packages.outputs.result }}}"
         if: ${{ inputs.skip-download == 'false' }}
         shell: bash
         working-directory: ${{ inputs.charts-dir }}/${{ inputs.artifact-dir }}


### PR DESCRIPTION
when a requested file doesn't exist on GitHub pages, it returns a `HTTP 301 Moved` response. We should fail the download and abort the workflow. Otherwise it downloads a file and overwrites local `index.yaml` or chart versions. 
Previously we only used the `--fail` option for curl, but additionally we have to follow the redirect (`-L`) to get the correct `HTTP 404` status. 

