### PR TITLE
Add ref to lint job

### DIFF
--- a/.github/workflows/helm-multi-release.yaml
+++ b/.github/workflows/helm-multi-release.yaml
@@ -53,6 +53,7 @@ jobs:
         uses: bakdata/ci-templates/actions/helm-lint@v1.10.0
         with:
           lint-config-path: "${{ inputs.lint-config-path }}"
+          ref: ${{ github.ref_name }}
 
   update-version:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Lint job should use the current branch and not the default branch