### PR TITLE
Change output method

### DIFF
--- a/actions/bump-version/action.yaml
+++ b/actions/bump-version/action.yaml
@@ -28,8 +28,8 @@ runs:
     - name: Bump version
       id: release-tag
       run: |
-        echo ::set-output name=oldTag::$(python -c "from configparser import ConfigParser; cfg = ConfigParser(); cfg.read('.bumpversion.cfg'); print(cfg['bumpversion']['current_version'])")
+        echo "oldTag=$(python -c "from configparser import ConfigParser; cfg = ConfigParser(); cfg.read('.bumpversion.cfg'); print(cfg['bumpversion']['current_version'])")" >> "$GITHUB_OUTPUT"
         bump2version ${{ inputs.release-type }} --no-commit
-        echo ::set-output name=newTag::$(python -c "from configparser import ConfigParser; cfg = ConfigParser(); cfg.read('.bumpversion.cfg'); print(cfg['bumpversion']['current_version'])")
+        echo "newTag=$(python -c "from configparser import ConfigParser; cfg = ConfigParser(); cfg.read('.bumpversion.cfg'); print(cfg['bumpversion']['current_version'])")" >> "$GITHUB_OUTPUT"
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/actions/bump-version/scripts/get_version.py
+++ b/actions/bump-version/scripts/get_version.py
@@ -1,6 +1,0 @@
-from configparser import ConfigParser
-
-
-cfg = ConfigParser()
-cfg.read('.bumpversion.cfg')
-print(cfg['bumpversion']['current_version'])


### PR DESCRIPTION
Fixes #63
Fixes #34
I removed the `scripts` dir.  Since the version [v1.13.2](https://github.com/bakdata/ci-templates/blob/v1.13.2/actions/bump-version/action.yaml) was working just fine, i am not seeing any reason why we should create an extra python file.

I solved [the initial issue](https://github.com/bakdata/ci-templates/issues/34) using [this approach](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).