### PR TITLE
Move checkout and login from Docker actions to workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -32,26 +32,28 @@ This workflow is built from multiple composite actions listed below:
 
 ### Input Parameters
 
-| Name                | Required |        Default Value         |  Type  | Description                                                                                                                                         |
-| ------------------- | :------: | :--------------------------: | :----: | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| docker-context      |    ❌    |             "."              | string | The docker context.                                                                                                                                 |
-| dockerfile-path     |    ❌    |         "Dockerfile"         | string | Path to the Dockerfile.                                                                                                                             |
-| docker-registry     |    ❌    |              ""              | string | Host where the image should be pushed to.                                                                                                           |
-| image-artifact-name |    ❌    |       "image-artifact"       | string | Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact (Default is 'image-artifact'). |
-| image-name          |    ❌    | github.event.repository.name | string | Name of Docker image (Default is the repository name).                                                                                              |
-| ref                 |    ❌    |              ""              | string | The ref name to checkout the repository                                                                                                             |
-| working-directory   |    ❌    |             "."              | string | Working directory for your Docker artifacts. (Default is .)                                                                                         |
+| Name                | Required |                   Default Value                    |  Type  | Description                                                                                                          |
+| ------------------- | :------: | :------------------------------------------------: | :----: | -------------------------------------------------------------------------------------------------------------------- |
+| docker-context      |    ❌    |                        "."                         | string | The docker context                                                                                                   |
+| dockerfile-path     |    ❌    |                    "Dockerfile"                    | string | Path to the Dockerfile                                                                                               |
+| docker-registry     |    ❌    |                         ""                         | string | Host where the image should be pushed to                                                                             |
+| image-repository    |    ❌    |                         ""                         | string | Repository of Docker image                                                                                           |
+| image-name          |    ❌    |            github.event.repository.name            | string | Name of Docker image                                                                                                 |
+| image-tag           |    ❌    | pipeline-${{ github.run_id }}-git-${GITHUB_SHA::8} | string | Tag of Docker image                                                                                                  |
+| ref                 |    ❌    |                         ""                         | string | The ref name to checkout                                                                                             |
+| retention-days      |    ❌    |                         1                          | string | Number of days the image artifact should be stored on GitHub                                                         |
+| image-artifact-name |    ❌    |                  "image-artifact"                  | string | Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact |
+| working-directory   |    ❌    |                        "."                         | string | Working directory for your Docker artifacts                                                                          |
 
 ### Secret Parameters
 
 These secrets define the user that pushes the built images to the container registry.
 
-| Name             | Required | Description                                             |
-| ---------------- | :------: | ------------------------------------------------------- |
-| docker-publisher |    ✅    | Publisher to prefix Docker image (e.g. 'my-publisher'). |
-| docker-user      |    ✅    | Username for the Docker registry login.                 |
-| docker-password  |    ✅    | Password for the Docker registry login.                 |
-| github-token     |    ❌    | The GitHub token for committing the changes             |
+| Name            | Required | Description                                 |
+| --------------- | :------: | ------------------------------------------- |
+| docker-user     |    ✅    | Username for the Docker registry login      |
+| docker-password |    ✅    | Password for the Docker registry login      |
+| github-token    |    ❌    | The GitHub token for committing the changes |
 
 ### Calling the workflow
 
@@ -66,15 +68,18 @@ jobs:
     name: Build and push Docker image
     uses: bakdata/ci-templates/.github/workflows/docker-build-and-publish.yaml@main
     with:
-      dockerfile-context: "./docker-dir/"
+      # with these settings image would be pushed to my-registry.com/my-repository/my-image:my-tag
+      docker-context: "./docker-dir/"
       dockerfile-path: "./path/to/my/Dockerfile"
       docker-registry: "my-registry.com"
+      image-repository: "my-repository"
       image-name: "my-image"
+      image-tag: "my-tag"
+      ref: "feat/foo"
+      retention-days: 2
       image-artifact-name: "my-image-artifact"
       working-directory: "."
-
     secrets:
-      docker-publisher: "${{ secrets.DOCKER_PUBLISHER }}"
       docker-user: "${{ secrets.DOCKER_USER }}"
       docker-password: "${{ secrets.DOCKER_PWD }}"
       github-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/docker-build-and-publish.yaml
+++ b/.github/workflows/docker-build-and-publish.yaml
@@ -46,7 +46,8 @@ on:
       docker-password:
         description: "Password for the Docker registry login."
         required: true
-      # if this workflow should be automatically triggered after a new tag was pushed by another action, then configure the github token to overcome it (as described here: https://github.com/orgs/community/discussions/27028)
+      # if this workflow should be automatically triggered after a new tag was pushed by another action,
+      # then configure the github token to overcome it (as described here: https://github.com/orgs/community/discussions/27028)
       github-token:
         description: "GitHub token."
         required: false

--- a/.github/workflows/docker-build-and-publish.yaml
+++ b/.github/workflows/docker-build-and-publish.yaml
@@ -81,7 +81,7 @@ jobs:
           persist-credentials: false
 
       - name: Build docker image and upload tar file
-        uses: bakdata/ci-templates/actions/docker-build@v1.14.0
+        uses: bakdata/ci-templates/actions/docker-build@fix/docker
         with:
           docker-context: "${{ inputs.docker-context }}"
           dockerfile-path: "${{ inputs.dockerfile-path }}"
@@ -103,7 +103,7 @@ jobs:
           password: "${{ secrets.docker-password }}"
 
       - name: Use uploaded tar files to push new image to docker
-        uses: bakdata/ci-templates/actions/docker-publish@v1.14.0
+        uses: bakdata/ci-templates/actions/docker-publish@fix/docker
         with:
           docker-registry: "${{ inputs.docker-registry }}"
           image-repository: "${{ inputs.image-repository }}"

--- a/.github/workflows/docker-build-and-publish.yaml
+++ b/.github/workflows/docker-build-and-publish.yaml
@@ -81,7 +81,7 @@ jobs:
           persist-credentials: false
 
       - name: Build docker image and upload tar file
-        uses: bakdata/ci-templates/actions/docker-build@fix/docker
+        uses: bakdata/ci-templates/actions/docker-build@v1.18.0
         with:
           docker-context: "${{ inputs.docker-context }}"
           dockerfile-path: "${{ inputs.dockerfile-path }}"
@@ -103,7 +103,7 @@ jobs:
           password: "${{ secrets.docker-password }}"
 
       - name: Use uploaded tar files to push new image to docker
-        uses: bakdata/ci-templates/actions/docker-publish@fix/docker
+        uses: bakdata/ci-templates/actions/docker-publish@v1.18.0
         with:
           docker-registry: "${{ inputs.docker-registry }}"
           image-repository: "${{ inputs.image-repository }}"

--- a/.github/workflows/docker-build-and-publish.yaml
+++ b/.github/workflows/docker-build-and-publish.yaml
@@ -19,20 +19,35 @@ on:
         required: false
         default: ""
         type: string
-      image-artifact-name:
-        description: "Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact (Default is 'image-artifact')."
+      image-repository:
+        description: "Repository of Docker image."
         required: false
-        default: "image-artifact"
+        default: ""
         type: string
       image-name:
-        description: "Name of Docker image (Default is the repository name)."
+        description: "Name of Docker image."
         required: false
         default: "${{ github.event.repository.name }}"
+        type: string
+      image-tag:
+        description: "Tag of Docker image."
+        required: false
+        default: "pipeline-${{ github.run_id }}-git-${GITHUB_SHA::8}"
         type: string
       ref:
         description: "Ref to checkout"
         required: false
         default: ""
+        type: string
+      retention-days:
+        description: "Number of days the image artifact should be stored on GitHub."
+        required: false
+        default: 1
+        type: number
+      image-artifact-name:
+        description: "Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact."
+        required: false
+        default: "image-artifact"
         type: string
       working-directory:
         description: "Working directory for your Docker artifacts. (Default is .)"
@@ -70,8 +85,10 @@ jobs:
         with:
           docker-context: "${{ inputs.docker-context }}"
           dockerfile-path: "${{ inputs.dockerfile-path }}"
-          image-artifact-name: "${{ inputs.image-artifact-name }}"
           image-name: "${{ inputs.image-name }}"
+          image-artifact-name: "${{ inputs.image-artifact-name }}"
+          retention-days: "${{ inputs.retention-days }}"
+          working-directory: "${{ inputs.working-directory }}"
 
   docker-publish:
     name: Docker publish
@@ -89,6 +106,8 @@ jobs:
         uses: bakdata/ci-templates/actions/docker-publish@v1.14.0
         with:
           docker-registry: "${{ inputs.docker-registry }}"
-          image-artifact-name: "${{ inputs.image-artifact-name }}"
+          image-repository: "${{ inputs.image-repository }}"
           image-name: "${{ inputs.image-name }}"
+          image-tag: "${{ ipnuts.image-tag }}"
+          image-artifact-name: "${{ inputs.image-artifact-name }}"
           working-directory: "${{ inputs.working-directory }}"

--- a/.github/workflows/docker-build-and-publish.yaml
+++ b/.github/workflows/docker-build-and-publish.yaml
@@ -77,12 +77,17 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [docker-build]
     steps:
+      - name: Login to the Registry
+        uses: "docker/login-action@v2.1.0"
+        with:
+          registry: "${{ inputs.docker-registry }}"
+          username: "${{ secrets.docker-user }}"
+          password: "${{ secrets.docker-password }}"
+
       - name: Use uploaded tar files to push new image to docker
         uses: bakdata/ci-templates/actions/docker-publish@v1.14.0
         with:
+          docker-registry: "${{ inputs.docker-registry }}"
           image-artifact-name: "${{ inputs.image-artifact-name }}"
           image-name: "${{ inputs.image-name }}"
-          username: "${{ secrets.docker-user }}"
-          password: "${{ secrets.docker-password }}"
           working-directory: "${{ inputs.working-directory }}"
-          docker-registry: "${{ inputs.docker-registry }}"

--- a/.github/workflows/docker-build-and-publish.yaml
+++ b/.github/workflows/docker-build-and-publish.yaml
@@ -108,6 +108,6 @@ jobs:
           docker-registry: "${{ inputs.docker-registry }}"
           image-repository: "${{ inputs.image-repository }}"
           image-name: "${{ inputs.image-name }}"
-          image-tag: "${{ ipnuts.image-tag }}"
+          image-tag: "${{ inputs.image-tag }}"
           image-artifact-name: "${{ inputs.image-artifact-name }}"
           working-directory: "${{ inputs.working-directory }}"

--- a/.github/workflows/docker-build-and-publish.yaml
+++ b/.github/workflows/docker-build-and-publish.yaml
@@ -35,7 +35,7 @@ on:
         default: "pipeline-${{ github.run_id }}-git-${GITHUB_SHA::8}"
         type: string
       ref:
-        description: "Ref to checkout"
+        description: "Ref name to checkout"
         required: false
         default: ""
         type: string

--- a/.github/workflows/docker-build-and-publish.yaml
+++ b/.github/workflows/docker-build-and-publish.yaml
@@ -40,9 +40,6 @@ on:
         default: "."
         type: string
     secrets:
-      docker-publisher:
-        description: "Publisher to prefix Docker image (e.g. 'my-publisher')."
-        required: true
       docker-user:
         description: "Username for the Docker registry login."
         required: true
@@ -85,7 +82,6 @@ jobs:
         with:
           image-artifact-name: "${{ inputs.image-artifact-name }}"
           image-name: "${{ inputs.image-name }}"
-          publisher: "${{ secrets.docker-publisher }}"
           username: "${{ secrets.docker-user }}"
           password: "${{ secrets.docker-password }}"
           working-directory: "${{ inputs.working-directory }}"

--- a/.github/workflows/docker-build-and-publish.yaml
+++ b/.github/workflows/docker-build-and-publish.yaml
@@ -60,15 +60,20 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+          token: ${{ secrets.github-token }}
+          persist-credentials: false
+
       - name: Build docker image and upload tar file
         uses: bakdata/ci-templates/actions/docker-build@v1.14.0
         with:
           docker-context: "${{ inputs.docker-context }}"
           dockerfile-path: "${{ inputs.dockerfile-path }}"
-          github-token: "${{ secrets.github-token }}"
           image-artifact-name: "${{ inputs.image-artifact-name }}"
           image-name: "${{ inputs.image-name }}"
-          ref: "${{ inputs.ref }}"
 
   docker-publish:
     name: Docker publish

--- a/actions/docker-build/README.md
+++ b/actions/docker-build/README.md
@@ -15,6 +15,7 @@ Ensure that your Dockerfile is uploaded to the repository you want to use this a
 | image-artifact-name |    ❌    |       "image-artifact"       | Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact |
 | image-name          |    ❌    | github.event.repository.name | Name of Docker image on Dockerhub                                                                                    |
 | retention-days      |    ❌    |              1               | Number of days the image artifact should be stored on GitHub                                                         |
+| working-directory   |    ❌    |             "."              | Working directory for your Docker artifacts                                                                          |
 
 ## Usage
 

--- a/actions/docker-build/README.md
+++ b/actions/docker-build/README.md
@@ -12,8 +12,8 @@ Ensure that your Dockerfile is uploaded to the repository you want to use this a
 | ------------------- | :------: | :--------------------------: | -------------------------------------------------------------------------------------------------------------------- |
 | docker-context      |    ❌    |             "."              | The docker context.                                                                                                  |
 | dockerfile-path     |    ❌    |         "Dockerfile"         | Path to the Dockerfile.                                                                                              |
-| image-artifact-name |    ❌    |       "image-artifact"       | Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact |
 | image-name          |    ❌    | github.event.repository.name | Name of Docker image on Dockerhub                                                                                    |
+| image-artifact-name |    ❌    |       "image-artifact"       | Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact |
 | retention-days      |    ❌    |              1               | Number of days the image artifact should be stored on GitHub                                                         |
 | working-directory   |    ❌    |             "."              | Working directory for your Docker artifacts                                                                          |
 
@@ -24,7 +24,7 @@ steps:
   - name: Build
     uses: bakdata/ci-templates/actions/docker-build@main
     with:
-      dockerfile-context: "./docker-dir/"
+      docker-context: "./docker-dir/"
       dockerfile-path: "./path/to/my/Dockerfile"
       image-artifact-name: "my-image-artifact"
       image-name: "my-image"

--- a/actions/docker-build/README.md
+++ b/actions/docker-build/README.md
@@ -29,4 +29,5 @@ steps:
       image-artifact-name: "my-image-artifact"
       image-name: "my-image"
       retention-days: 2
+      working-directory: "./tarball"
 ```

--- a/actions/docker-build/README.md
+++ b/actions/docker-build/README.md
@@ -8,13 +8,13 @@ Ensure that your Dockerfile is uploaded to the repository you want to use this a
 
 ## Input Parameters
 
-| Name                | Required |        Default Value         |                                                                     Description                                                                     |
-| ------------------- | :------: | :--------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------: |
-| docker-context      |    ❌    |             "."              |                                                                 The docker context.                                                                 |
-| dockerfile-path     |    ❌    |         "Dockerfile"         |                                                               Path to the Dockerfile.                                                               |
-| image-artifact-name |    ❌    |       "image-artifact"       | Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact (Default is 'image-artifact'). |
-| image-name          |    ❌    | github.event.repository.name |                                                          Name of Docker image on Dockerhub                                                          |
-| retention-days      |    ❌    |              1               |                                            Number of days the image artifact should be stored on GitHub.                                            |
+| Name                | Required |        Default Value         | Description                                                                                                          |
+| ------------------- | :------: | :--------------------------: | -------------------------------------------------------------------------------------------------------------------- |
+| docker-context      |    ❌    |             "."              | The docker context.                                                                                                  |
+| dockerfile-path     |    ❌    |         "Dockerfile"         | Path to the Dockerfile.                                                                                              |
+| image-artifact-name |    ❌    |       "image-artifact"       | Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact |
+| image-name          |    ❌    | github.event.repository.name | Name of Docker image on Dockerhub                                                                                    |
+| retention-days      |    ❌    |              1               | Number of days the image artifact should be stored on GitHub                                                         |
 
 ## Usage
 

--- a/actions/docker-build/README.md
+++ b/actions/docker-build/README.md
@@ -10,7 +10,7 @@ Ensure that your Dockerfile is uploaded to the repository you want to use this a
 
 | Name                | Required |        Default Value         |                                                                     Description                                                                     |
 | ------------------- | :------: | :--------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------: |
-| dockerfile-context  |    ❌    |             "."              |                                                                 The docker context.                                                                 |
+| docker-context      |    ❌    |             "."              |                                                                 The docker context.                                                                 |
 | dockerfile-path     |    ❌    |         "Dockerfile"         |                                                               Path to the Dockerfile.                                                               |
 | image-artifact-name |    ❌    |       "image-artifact"       | Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact (Default is 'image-artifact'). |
 | image-name          |    ❌    | github.event.repository.name |                                                          Name of Docker image on Dockerhub                                                          |
@@ -20,11 +20,12 @@ Ensure that your Dockerfile is uploaded to the repository you want to use this a
 
 ```yaml
 steps:
-  - name: Build tarball image
+  - name: Build
     uses: bakdata/ci-templates/actions/docker-build@main
     with:
       dockerfile-context: "./docker-dir/"
       dockerfile-path: "./path/to/my/Dockerfile"
       image-artifact-name: "my-image-artifact"
       image-name: "my-image"
+      retention-days: 2
 ```

--- a/actions/docker-build/README.md
+++ b/actions/docker-build/README.md
@@ -8,14 +8,13 @@ Ensure that your Dockerfile is uploaded to the repository you want to use this a
 
 ## Input Parameters
 
-| Name                | Required |        Default Value         |                                                                             Description                                                                              |
-| ------------------- | :------: | :--------------------------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-| dockerfile-context  |    ❌    |             "."              |                                                                         The docker context.                                                                          |
-| dockerfile-path     |    ❌    |         "Dockerfile"         |                                                                       Path to the Dockerfile.                                                                        |
-| github-token        |    ❌    |         github.token         | Github token to use for checkout(important when this action should be automatically triggerd by another action: https://github.com/orgs/community/discussions/27028) |
-| image-artifact-name |    ❌    |       "image-artifact"       |         Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact (Default is 'image-artifact').          |
-| image-name          |    ❌    | github.event.repository.name |                                                                  Name of Docker image on Dockerhub                                                                   |
-| ref                 |    ❌    |              ""              |                                                                   Branch to use for the checkout.                                                                    |
+| Name                | Required |        Default Value         |                                                                     Description                                                                     |
+| ------------------- | :------: | :--------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------: |
+| dockerfile-context  |    ❌    |             "."              |                                                                 The docker context.                                                                 |
+| dockerfile-path     |    ❌    |         "Dockerfile"         |                                                               Path to the Dockerfile.                                                               |
+| image-artifact-name |    ❌    |       "image-artifact"       | Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact (Default is 'image-artifact'). |
+| image-name          |    ❌    | github.event.repository.name |                                                          Name of Docker image on Dockerhub                                                          |
+| retention-days      |    ❌    |              1               |                                            Number of days the image artifact should be stored on GitHub.                                            |
 
 ## Usage
 
@@ -28,5 +27,4 @@ steps:
       dockerfile-path: "./path/to/my/Dockerfile"
       image-artifact-name: "my-image-artifact"
       image-name: "my-image"
-      github-token: "${{ secrets.GH_TOKEN }}"
 ```

--- a/actions/docker-build/action.yaml
+++ b/actions/docker-build/action.yaml
@@ -15,9 +15,13 @@ inputs:
     required: false
     default: "image-artifact"
   image-name:
-    description: "Name of Docker image (Default is the repository name)."
+    description: "Name of Docker image."
     required: false
     default: "${{ github.event.repository.name }}"
+  image-tag:
+    description: "Tag of Docker image."
+    required: false
+    default: "pipeline-${{ github.run_id }}-git-${GITHUB_SHA::8}"
   retention-days:
     description: "Number of days the image artifact should be stored on GitHub."
     required: false
@@ -27,9 +31,9 @@ runs:
   steps:
     - name: Build Dockerfile and store them in "build" directory
       run: |
-        docker build -t ${{ inputs.image-name }}:${{ github.run_id }} -f ${{ inputs.dockerfile-path }} ${{ inputs.docker-context }}
+        docker build -t ${{ inputs.image-name }}:${{ inputs.image-tag }} -f ${{ inputs.dockerfile-path }} ${{ inputs.docker-context }}
         mkdir build
-        docker save ${{ inputs.image-name }}:${{ github.run_id }} > build/${{ inputs.image-name }}.tar
+        docker save ${{ inputs.image-name }}:${{ inputs.image-tag }} > build/${{ inputs.image-name }}.tar
       shell: bash
 
     - name: Upload Docker image tar artifact

--- a/actions/docker-build/action.yaml
+++ b/actions/docker-build/action.yaml
@@ -27,7 +27,7 @@ runs:
   steps:
     - name: Build Dockerfile and store them in "build" directory
       run: |
-        docker build -t ${{ inputs.image-name }}-f ${{ inputs.dockerfile-path }} ${{ inputs.docker-context }}
+        docker build -t ${{ inputs.image-name }} -f ${{ inputs.dockerfile-path }} ${{ inputs.docker-context }}
         mkdir build
         docker save ${{ inputs.image-name }} > build/${{ inputs.image-name }}.tar
       shell: bash

--- a/actions/docker-build/action.yaml
+++ b/actions/docker-build/action.yaml
@@ -10,11 +10,6 @@ inputs:
     description: "Path to the Dockerfile."
     required: false
     default: "Dockerfile"
-  github-token:
-    # if this action should be automatically triggered after a new tag was pushed by another action, this action will not be triggered. Configure the github token to overcome it (as described here: https://github.com/orgs/community/discussions/27028)
-    description: "GitHub token"
-    required: false
-    default: "${{ github.token }}"
   image-artifact-name:
     description: "Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact (Default is 'image-artifact')."
     required: false
@@ -23,20 +18,13 @@ inputs:
     description: "Name of Docker image (Default is the repository name)."
     required: false
     default: "${{ github.event.repository.name }}"
-  ref:
-    description: "Ref to checkout"
+  retention-days:
+    description: "Number of days the image artifact should be stored on GitHub."
     required: false
-    default: ""
+    default: 1
 runs:
   using: "composite"
   steps:
-    - name: Check out repository
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ inputs.ref }}
-        token: ${{ inputs.github-token }}
-        persist-credentials: false
-
     - name: Build Dockerfile and store them in "build" directory
       run: |
         docker build -t ${{ inputs.image-name }}:${{ github.run_id }} -f ${{ inputs.dockerfile-path }} ${{ inputs.docker-context }}
@@ -49,4 +37,4 @@ runs:
       with:
         name: ${{ inputs.image-artifact-name }}
         path: build
-        retention-days: 1
+        retention-days: ${{ inputs.retention-days }}

--- a/actions/docker-build/action.yaml
+++ b/actions/docker-build/action.yaml
@@ -22,6 +22,10 @@ inputs:
     description: "Number of days the image artifact should be stored on GitHub."
     required: false
     default: 1
+  working-directory:
+    description: "Working directory for your Docker artifacts."
+    required: false
+    default: "."
 runs:
   using: "composite"
   steps:
@@ -31,6 +35,7 @@ runs:
         mkdir build
         docker save ${{ inputs.image-name }} > build/${{ inputs.image-name }}.tar
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Upload Docker image tar artifact
       uses: actions/upload-artifact@v3.1.1

--- a/actions/docker-build/action.yaml
+++ b/actions/docker-build/action.yaml
@@ -18,10 +18,6 @@ inputs:
     description: "Name of Docker image."
     required: false
     default: "${{ github.event.repository.name }}"
-  image-tag:
-    description: "Tag of Docker image."
-    required: false
-    default: "pipeline-${{ github.run_id }}-git-${GITHUB_SHA::8}"
   retention-days:
     description: "Number of days the image artifact should be stored on GitHub."
     required: false
@@ -31,9 +27,9 @@ runs:
   steps:
     - name: Build Dockerfile and store them in "build" directory
       run: |
-        docker build -t ${{ inputs.image-name }}:${{ inputs.image-tag }} -f ${{ inputs.dockerfile-path }} ${{ inputs.docker-context }}
+        docker build -t ${{ inputs.image-name }}-f ${{ inputs.dockerfile-path }} ${{ inputs.docker-context }}
         mkdir build
-        docker save ${{ inputs.image-name }}:${{ inputs.image-tag }} > build/${{ inputs.image-name }}.tar
+        docker save ${{ inputs.image-name }} > build/${{ inputs.image-name }}.tar
       shell: bash
 
     - name: Upload Docker image tar artifact

--- a/actions/docker-publish/README.md
+++ b/actions/docker-publish/README.md
@@ -1,6 +1,6 @@
 # docker-publish
 
-This action downloads an `image.tar` file from an artifact and publishes it on Dockerhub. When this action is used on a tag branch, the image is tagged with `latest` and the tag version of the branch (e.g. `1.2.3`). For all other branches, the `github.run_id` is used as an image tag.
+This action downloads an `image.tar` file from an artifact and publishes it into a Docker registry. When this action is used on a tag branch, the image is tagged with `latest` and the tag version of the branch (e.g. `1.2.3`). For all other branches, the tag `pipeline-${{ github.run_id }}-git-${GITHUB_SHA::8}` is used as an image tag.
 
 ## Prerequisites
 

--- a/actions/docker-publish/README.md
+++ b/actions/docker-publish/README.md
@@ -24,12 +24,11 @@ steps:
   - name: Publish tarball image
     uses: bakdata/ci-templates/actions/docker-publish@main
     with:
-      image-tag: "v.1.0"
-      image-name: "tarball"
-      publisher: "my-publisher"
-      username: "${{ secrets.docker-user }}"
-      password: "${{ secrets.docker-password }}"
+      # publishing image registry.hub.docker.com/my-repo/my-image:v1.1.0
+      docker-registry: "registry.hub.docker.com"
+      image-repository: "my-repo"
+      image-name: "my-image"
+      image-tag: "v1.1.0"
+      image-artifact-name: "tarball"
       working-directory: "./tarball"
-      github-token: "${{ secrets.GITHUB_TOKEN }}"
-      ref: "master" # (Optional)
 ```

--- a/actions/docker-publish/README.md
+++ b/actions/docker-publish/README.md
@@ -8,15 +8,14 @@ Create an action that [uploads a tarball image as an artifact](https://github.co
 
 ## Input Parameters
 
-| Name                | Required |        Default Value         | Description                                                                                                                                         |
-| ------------------- | :------: | :--------------------------: | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| password            |    ✅    |              -               | Password for the Docker registry login                                                                                                              |
-| publisher           |    ✅    |              -               | Publisher to prefix Docker image (e.g. 'my-publisher')                                                                                              |
-| username            |    ✅    |              -               | Username for the Docker registry login                                                                                                              |
-| docker-registry     |    ❌    |              ""              | Host where the image should be pushed to.                                                                                                           |
-| image-artifact-name |    ❌    |       "image-artifact"       | Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact (Default is 'image-artifact'). |
-| image-name          |    ❌    | github.event.repository.name | Name of Docker image on Dockerhub                                                                                                                   |
-| working-directory   |    ❌    |              -               | Working directory for your Docker artifacts                                                                                                         |
+| Name                | Required |                   Default Value                    | Description                                                                                                          |
+| ------------------- | :------: | :------------------------------------------------: | -------------------------------------------------------------------------------------------------------------------- |
+| docker-registry     |    ❌    |                         ""                         | Host where the image should be pushed to                                                                             |
+| image-repository    |    ❌    |                         ""                         | Repository of Docker image                                                                                           |
+| image-name          |    ❌    |            github.event.repository.name            | Name of Docker image                                                                                                 |
+| image-tag           |    ❌    | pipeline-${{ github.run_id }}-git-${GITHUB_SHA::8} | Tag of Docker image                                                                                                  |
+| image-artifact-name |    ❌    |                  "image-artifact"                  | Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact |
+| working-directory   |    ❌    |                        "."                         | Working directory for your Docker artifacts                                                                          |
 
 ## Usage
 

--- a/actions/docker-publish/action.yaml
+++ b/actions/docker-publish/action.yaml
@@ -63,7 +63,7 @@ runs:
         fi
 
         fullImageName="${{ inputs.image-name }}"
-        if [[ -n "${{ inputs.image-registry }}" ]]; then
+        if [[ -n "${{ inputs.docker-registry }}" ]]; then
           if [[ -n "${{ inputs.image-repository }}" ]]; then
             fullImageName="${{ inputs.image-repository }}/${fullImageName}"
           fi

--- a/actions/docker-publish/action.yaml
+++ b/actions/docker-publish/action.yaml
@@ -45,8 +45,8 @@ runs:
 
     # setup-buildx action will create and boot a builder using by default the docker-container driver.
     # This is not required but recommended using it to be able to build multi-platform images, export cache, etc.
-    # - name: Set up Docker Buildx
-    #   uses: docker/setup-buildx-action@v2.2.1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2.2.1
 
     - name: Publish image
       run: |
@@ -71,7 +71,6 @@ runs:
           docker push ${fullImageName}:${GITHUB_REF/refs\/tags\//}
         else
           docker tag ${{ inputs.image-name }} ${fullImageName}:${{ inputs.image-tag }}
-          docker images
           docker push ${fullImageName}:${{ inputs.image-tag }}
         fi
       shell: bash

--- a/actions/docker-publish/action.yaml
+++ b/actions/docker-publish/action.yaml
@@ -4,10 +4,12 @@ description: "Publish Docker image from download artifact to any host"
 inputs:
   username:
     description: "Username for the Docker registry login."
-    required: true
+    required: false 
+    default: ""
   password:
     description: "Password for the Docker registry login."
-    required: true
+    required: false
+    default: ""
   docker-registry:
     description: "Host where the image should be pushed to."
     required: false

--- a/actions/docker-publish/action.yaml
+++ b/actions/docker-publish/action.yaml
@@ -2,27 +2,28 @@ name: "Publish Docker image"
 description: "Publish Docker image from download artifact to any host"
 
 inputs:
-  password:
-    description: "Password for the Docker registry login."
-    required: true
-  publisher:
-    description: "Publisher to prefix Docker image (e.g. 'my-publisher')."
-    required: true
   username:
     description: "Username for the Docker registry login."
+    required: true
+  password:
+    description: "Password for the Docker registry login."
     required: true
   docker-registry:
     description: "Host where the image should be pushed to."
     required: false
     default: ""
-  image-artifact-name:
-    description: "Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact (Default is 'image-artifact')."
-    required: false
-    default: "image-artifact"
   image-name:
     description: "Name of Docker image (Default is the repository name)."
     required: false
     default: "${{ github.event.repository.name }}"
+  image-tag:
+    description: "Tag of Docker image."
+    required: false
+    default: "pipeline-${{ github.run_id }}-git-${GITHUB_SHA::8}"
+  image-artifact-name:
+    description: "Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact (Default is 'image-artifact')."
+    required: false
+    default: "image-artifact"
   working-directory:
     description: "Working directory for your Docker artifacts. (Default is .)"
     required: false
@@ -50,25 +51,20 @@ runs:
 
     - name: Publish image
       run: |
-        docker_reg=""
-        if [ -n "${{ inputs.docker-registry }}" ]; then 
-          docker_reg="${{ inputs.docker-registry }}/"
-        fi
-        reg_pub_name="${docker_reg}${{ inputs.publisher }}/${{ inputs.image-name }}"
-
         if [[ $(ls -1 build/*.tar 2>/dev/null | wc -l) != 1 ]]; then
           >&2 echo "Error: A single image tar file is needed in the downloaded artifact. You can upload one before using this action: https://github.com/actions/upload-artifact."
           exit 1
         fi
+
         docker load --input build/*.tar
         if [[ "$GITHUB_REF" =~ ^refs/tags/.* ]]; then
-          docker tag ${{ inputs.image-name }}:${{ github.run_id }} $reg_pub_name:latest
-          docker tag ${{ inputs.image-name }}:${{ github.run_id }} $reg_pub_name:${GITHUB_REF/refs\/tags\//}
-          docker push $reg_pub_name:latest
-          docker push $reg_pub_name:${GITHUB_REF/refs\/tags\//}
+          docker tag ${{ inputs.image-name }}:${{ inputs.image-tag }} ${{ inputs.docker-registry }}:latest
+          docker tag ${{ inputs.image-name }}:${{ inputs.image-tag }} ${{ inputs.docker-registry }}:${GITHUB_REF/refs\/tags\//}
+          docker push ${{ inputs.docker-registry }}:latest
+          docker push ${{ inputs.docker-registry }}:${GITHUB_REF/refs\/tags\//}
         else
-          docker tag ${{ inputs.image-name }}:${{ github.run_id }} $reg_pub_name:${{ github.run_id }}
-          docker push $reg_pub_name:${{ github.run_id }}
+          docker tag ${{ inputs.image-name }}:${{ inputs.image-tag }} ${{ inputs.docker-registry }}:${{ inputs.image-tag }}
+          docker push ${{ inputs.docker-registry }}:${{ inputs.image-tag }}
         fi
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/actions/docker-publish/action.yaml
+++ b/actions/docker-publish/action.yaml
@@ -15,7 +15,7 @@ inputs:
   image-repository:
     description: "Repository of Docker image."
     required: false
-    default: "${{ github.event.repository.name }}"
+    default: ""
   image-name:
     description: "Name of Docker image."
     required: false
@@ -25,11 +25,11 @@ inputs:
     required: false
     default: "pipeline-${{ github.run_id }}-git-${GITHUB_SHA::8}"
   image-artifact-name:
-    description: "Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact (Default is 'image-artifact')."
+    description: "Name of the artifact that contains the Docker image.tar file to push, see https://github.com/actions/upload-artifact."
     required: false
     default: "image-artifact"
   working-directory:
-    description: "Working directory for your Docker artifacts. (Default is .)"
+    description: "Working directory for your Docker artifacts."
     required: false
     default: "."
 runs:

--- a/actions/docker-publish/action.yaml
+++ b/actions/docker-publish/action.yaml
@@ -48,13 +48,6 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2.2.1
 
-    - name: Login to the Registry
-      uses: "docker/login-action@v2.1.0"
-      with:
-        registry: "${{ inputs.docker-registry }}"
-        username: "${{ inputs.username }}"
-        password: "${{ inputs.password }}"
-
     - name: Publish image
       run: |
         if [[ $(ls -1 build/*.tar 2>/dev/null | wc -l) != 1 ]]; then

--- a/actions/docker-publish/action.yaml
+++ b/actions/docker-publish/action.yaml
@@ -12,8 +12,12 @@ inputs:
     description: "Host where the image should be pushed to."
     required: false
     default: ""
+  image-repository:
+    description: "Repository of Docker image."
+    required: false
+    default: "${{ github.event.repository.name }}"
   image-name:
-    description: "Name of Docker image (Default is the repository name)."
+    description: "Name of Docker image."
     required: false
     default: "${{ github.event.repository.name }}"
   image-tag:
@@ -56,15 +60,23 @@ runs:
           exit 1
         fi
 
+        fullImageName="${{ inputs.image-name }}"
+        if [[ -n "${{ inputs.image-repository }}" ]]; then
+          fullImageName="${{ inputs.image-repository }}/${fullImageName}"
+        fi
+        if [[ -n "${{ inputs.image-registry }}"]]; then
+          fullImageName="${{ inputs.image-registry }}/${fullImageName}"
+        fi
+        
         docker load --input build/*.tar
         if [[ "$GITHUB_REF" =~ ^refs/tags/.* ]]; then
-          docker tag ${{ inputs.image-name }}:${{ inputs.image-tag }} ${{ inputs.docker-registry }}:latest
-          docker tag ${{ inputs.image-name }}:${{ inputs.image-tag }} ${{ inputs.docker-registry }}:${GITHUB_REF/refs\/tags\//}
-          docker push ${{ inputs.docker-registry }}:latest
-          docker push ${{ inputs.docker-registry }}:${GITHUB_REF/refs\/tags\//}
+          docker tag ${{ inputs.image-name }}:${{ inputs.image-tag }} ${fullImageName}:latest
+          docker tag ${{ inputs.image-name }}:${{ inputs.image-tag }} ${fullImageName}:${GITHUB_REF/refs\/tags\//}
+          docker push ${fullImageName}:latest
+          docker push ${fullImageName}:${GITHUB_REF/refs\/tags\//}
         else
-          docker tag ${{ inputs.image-name }}:${{ inputs.image-tag }} ${{ inputs.docker-registry }}:${{ inputs.image-tag }}
-          docker push ${{ inputs.docker-registry }}:${{ inputs.image-tag }}
+          docker tag ${{ inputs.image-name }}:${{ inputs.image-tag }} ${fullImageName}:${{ inputs.image-tag }}
+          docker push ${fullImageName}:${{ inputs.image-tag }}
         fi
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/actions/docker-publish/action.yaml
+++ b/actions/docker-publish/action.yaml
@@ -63,7 +63,7 @@ runs:
         fi
 
         fullImageName="${{ inputs.image-name }}"
-        if [[ -n "${{ inputs.image-registry }}"]]; then
+        if [[ -n "${{ inputs.image-registry }}" ]]; then
           if [[ -n "${{ inputs.image-repository }}" ]]; then
             fullImageName="${{ inputs.image-repository }}/${fullImageName}"
           fi

--- a/actions/docker-publish/action.yaml
+++ b/actions/docker-publish/action.yaml
@@ -4,7 +4,7 @@ description: "Publish Docker image from download artifact to any host"
 inputs:
   username:
     description: "Username for the Docker registry login."
-    required: false 
+    required: false
     default: ""
   password:
     description: "Password for the Docker registry login."
@@ -45,8 +45,8 @@ runs:
 
     # setup-buildx action will create and boot a builder using by default the docker-container driver.
     # This is not required but recommended using it to be able to build multi-platform images, export cache, etc.
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2.2.1
+    # - name: Set up Docker Buildx
+    #   uses: docker/setup-buildx-action@v2.2.1
 
     - name: Publish image
       run: |

--- a/actions/docker-publish/action.yaml
+++ b/actions/docker-publish/action.yaml
@@ -2,14 +2,6 @@ name: "Publish Docker image"
 description: "Publish Docker image from download artifact to any host"
 
 inputs:
-  username:
-    description: "Username for the Docker registry login."
-    required: false
-    default: ""
-  password:
-    description: "Password for the Docker registry login."
-    required: false
-    default: ""
   docker-registry:
     description: "Host where the image should be pushed to."
     required: false

--- a/actions/docker-publish/action.yaml
+++ b/actions/docker-publish/action.yaml
@@ -67,7 +67,7 @@ runs:
           if [[ -n "${{ inputs.image-repository }}" ]]; then
             fullImageName="${{ inputs.image-repository }}/${fullImageName}"
           fi
-          fullImageName="${{ inputs.image-registry }}/${fullImageName}"
+          fullImageName="${{ inputs.docker-registry }}/${fullImageName}"
         fi
 
         docker load --input build/*.tar

--- a/actions/docker-publish/action.yaml
+++ b/actions/docker-publish/action.yaml
@@ -72,12 +72,13 @@ runs:
 
         docker load --input build/*.tar
         if [[ "$GITHUB_REF" =~ ^refs/tags/.* ]]; then
-          docker tag ${{ inputs.image-name }}:${{ inputs.image-tag }} ${fullImageName}:latest
-          docker tag ${{ inputs.image-name }}:${{ inputs.image-tag }} ${fullImageName}:${GITHUB_REF/refs\/tags\//}
+          docker tag ${{ inputs.image-name }} ${fullImageName}:latest
+          docker tag ${{ inputs.image-name }} ${fullImageName}:${GITHUB_REF/refs\/tags\//}
           docker push ${fullImageName}:latest
           docker push ${fullImageName}:${GITHUB_REF/refs\/tags\//}
         else
-          docker tag ${{ inputs.image-name }}:${{ inputs.image-tag }} ${fullImageName}:${{ inputs.image-tag }}
+          docker tag ${{ inputs.image-name }} ${fullImageName}:${{ inputs.image-tag }}
+          docker images
           docker push ${fullImageName}:${{ inputs.image-tag }}
         fi
       shell: bash

--- a/actions/docker-publish/action.yaml
+++ b/actions/docker-publish/action.yaml
@@ -61,13 +61,13 @@ runs:
         fi
 
         fullImageName="${{ inputs.image-name }}"
-        if [[ -n "${{ inputs.image-repository }}" ]]; then
-          fullImageName="${{ inputs.image-repository }}/${fullImageName}"
-        fi
         if [[ -n "${{ inputs.image-registry }}"]]; then
+          if [[ -n "${{ inputs.image-repository }}" ]]; then
+            fullImageName="${{ inputs.image-repository }}/${fullImageName}"
+          fi
           fullImageName="${{ inputs.image-registry }}/${fullImageName}"
         fi
-        
+
         docker load --input build/*.tar
         if [[ "$GITHUB_REF" =~ ^refs/tags/.* ]]; then
           docker tag ${{ inputs.image-name }}:${{ inputs.image-tag }} ${fullImageName}:latest


### PR DESCRIPTION
Additionally the following changes were done:
- rename docker-publisher -> image-repository
- remove tagging in build action (only necessary when publishing)
- change default tag for docker images from `${{ github.run_id }}` to `pipeline-${{ github.run_id }}-git-${GITHUB_SHA::8}`
- allow both docker-registry and image-repository to be optional in image name
- introduce input for retention-days of GitHub artifact (default: 1)