### PR TITLE
Saving application version under _version.py file to support adding a…

### DIFF
--- a/actions/python-poetry-bump-version/action.yaml
+++ b/actions/python-poetry-bump-version/action.yaml
@@ -44,6 +44,8 @@ runs:
       run: |
         echo "oldTag=$(poetry version -s)" >> $GITHUB_OUTPUT 
         poetry version ${{ inputs.release-type }}
-        echo "newTag=$(poetry version -s)" >> $GITHUB_OUTPUT  
+        export NEW_TAG=$(poetry version -s)
+        echo "newTag=$NEW_TAG" >> $GITHUB_OUTPUT
+        echo "__version__ = '$NEW_TAG'" > kpops/_version.py
       shell: bash
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
Related to KPOPS pull request: https://github.com/bakdata/kpops/pull/200 which addreses https://github.com/bakdata/kpops/issues/199

The idea is to have a _version.py file containing the version which can be later on used to determine the version in the CLI command (see https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package)