### PR TITLE
Update setup-kubectl action to v3 major

### DIFF
--- a/actions/helm-gke-setup/action.yaml
+++ b/actions/helm-gke-setup/action.yaml
@@ -49,7 +49,7 @@ runs:
         project_id: ${{ inputs.gke-project }}
 
     - name: Install kubectl
-      uses: azure/setup-kubectl@v1
+      uses: azure/setup-kubectl@v3
       with:
         version: ${{ inputs.kubectl-version }}
 

--- a/actions/port-forward/action.yaml
+++ b/actions/port-forward/action.yaml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: Install kubectl
-      uses: azure/setup-kubectl@v1
+      uses: azure/setup-kubectl@v3
       with:
         version: ${{ inputs.kubectl-version }}
 


### PR DESCRIPTION
Gets rid of deprecation warning about Node.js 12 & `set-output` function