### PR TITLE
Revert "Configure version increment check in Helm lint (#70)"

### DIFF
--- a/actions/helm-lint/README.md
+++ b/actions/helm-lint/README.md
@@ -14,12 +14,11 @@ target-branch: "main"
 
 ## Input Parameters
 
-| Name                    | Required |       Default Value        |  Type  | Description                                                                                                                              |
-| ----------------------- | :------: | :------------------------: | :----: | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| ref                     |    ❌    |     The current branch     | string | The ref name to checkout the repository                                                                                                  |
-| lint-config-path        |    ❌    | ".github/lint-config.yaml" | string | The path to the lint configuration file (For an example see https://github.com/helm/chart-testing/blob/main/pkg/config/test_config.yaml) |
-| helm-version            |    ❌    |         "v3.10.1"          | string | The Helm version                                                                                                                         |
-| check-version-increment |    ❌    |           "true"           | string | Activates a check for chart version increments.                                                                                          |
+| Name             | Required |       Default Value        |  Type  | Description                                                                                                                              |
+| ---------------- | :------: | :------------------------: | :----: | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| ref              |    ❌    |     The current branch     | string | The ref name to checkout the repository                                                                                                  |
+| lint-config-path |    ❌    | ".github/lint-config.yaml" | string | The path to the lint configuration file (For an example see https://github.com/helm/chart-testing/blob/main/pkg/config/test_config.yaml) |
+| helm-version     |    ❌    |         "v3.10.1"          | string | The Helm version                                                                                                                         |
 
 ## Usage
 

--- a/actions/helm-lint/action.yaml
+++ b/actions/helm-lint/action.yaml
@@ -13,10 +13,6 @@ inputs:
     description: "The Helm version."
     required: false
     default: "v3.10.1"
-  check-version-increment:
-    description: "Activates a check for chart version increments."
-    required: false
-    default: "true"
 
 runs:
   using: "composite"
@@ -44,8 +40,8 @@ runs:
     - name: Run chart-testing (lint)
       run: |
         if [[ "${GITHUB_REF#refs/heads/}" == "main" || "${GITHUB_REF#refs/heads/}" == "master" ]]; then
-          ct lint --config ${{ inputs.lint-config-path }} --since HEAD^ --check-version-increment=${{ inputs.check-version-increment }}
+          ct lint --config ${{ inputs.lint-config-path }} --since HEAD^
         else
-          ct lint --config ${{ inputs.lint-config-path }} --check-version-increment=${{ inputs.check-version-increment }}
+          ct lint --config ${{ inputs.lint-config-path }}
         fi
       shell: bash


### PR DESCRIPTION
This reverts commit aecaea688691daf63e85a17ee4419aa8a3b057d8.

`check-version-increment` should be set through lint config file.
