### PR TITLE
Fix boolean evaluation for changelog creation

### DIFF
--- a/.github/workflows/python-poetry-release.yaml
+++ b/.github/workflows/python-poetry-release.yaml
@@ -101,6 +101,7 @@ jobs:
           github-username: ${{ secrets.github-username }}s
           github-email: ${{ secrets.github-email }}
           github-token: ${{ secrets.github-token }}
+          add-untracked: "true"
 
       - name: Tag and release
         uses: bakdata/ci-templates/actions/tag-and-release@v1.22.0

--- a/.github/workflows/python-poetry-release.yaml
+++ b/.github/workflows/python-poetry-release.yaml
@@ -94,7 +94,7 @@ jobs:
           fetch-release-information: "true"
 
       - name: Commit and push pyproject.toml file
-        uses: bakdata/ci-templates/actions/commit-and-push@v1.25.0
+        uses: bakdata/ci-templates/actions/commit-and-push@1.25.2
         with:
           ref: ${{ inputs.ref }}
           commit-message: "Bump version ${{ steps.bump-version.outputs.old-version }} → ${{ steps.bump-version.outputs.release-version }}"

--- a/.github/workflows/python-poetry-release.yaml
+++ b/.github/workflows/python-poetry-release.yaml
@@ -102,7 +102,6 @@ jobs:
           github-email: ${{ secrets.github-email }}
           github-token: ${{ secrets.github-token }}
           add-untracked: "true"
-          
 
       - name: Tag and release
         uses: bakdata/ci-templates/actions/tag-and-release@v1.22.0

--- a/.github/workflows/python-poetry-release.yaml
+++ b/.github/workflows/python-poetry-release.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: Create changelog
         id: build-changelog
         uses: bakdata/ci-templates/actions/changelog-generate@v1.21.1
-        if: ${{ inputs.changelog == 'true'}}
+        if: ${{ inputs.changelog == true}}
         with:
           github-token: ${{ secrets.github-token }}
           config: ${{ inputs.changelog-config }}

--- a/.github/workflows/python-poetry-release.yaml
+++ b/.github/workflows/python-poetry-release.yaml
@@ -94,7 +94,7 @@ jobs:
           fetch-release-information: "true"
 
       - name: Commit and push pyproject.toml file
-        uses: bakdata/ci-templates/actions/commit-and-push@v1.0.0
+        uses: bakdata/ci-templates/actions/commit-and-push@v1.25.0
         with:
           ref: ${{ inputs.ref }}
           commit-message: "Bump version ${{ steps.bump-version.outputs.old-version }} → ${{ steps.bump-version.outputs.release-version }}"
@@ -102,6 +102,7 @@ jobs:
           github-email: ${{ secrets.github-email }}
           github-token: ${{ secrets.github-token }}
           add-untracked: "true"
+          
 
       - name: Tag and release
         uses: bakdata/ci-templates/actions/tag-and-release@v1.22.0


### PR DESCRIPTION
it seems it is not getting this as a string

https://github.com/bakdata/kpops/blob/main/.github/workflows/release.yaml#L23

https://github.com/actions/runner/issues/2238
https://github.com/actions/runner/issues/1483

it seems it only applies when the input is from the dispatch and not as a fixed param