### PR TITLE
Add flag for installing pipx before poetry setup

### DIFF
--- a/actions/python-setup-poetry/action.yaml
+++ b/actions/python-setup-poetry/action.yaml
@@ -25,11 +25,9 @@ runs:
     - name: Install pipx
       if: ${{ inputs.install-pipx == 'true' }}
       run: |
-        sudo apt update
-        sudo apt install pipx -y
-        pipx ensurepath
-        # https://github.com/pypa/pipx/issues/853
-        virtualenv --clear /home/runner/.local/pipx/shared
+        # Assumes Ubuntu 22.04 or below
+        python3 -m pip install --user pipx
+        python3 -m pipx ensurepath
       shell: bash
 
     - name: Install Poetry ${{ inputs.poetry-version }}

--- a/actions/python-setup-poetry/action.yaml
+++ b/actions/python-setup-poetry/action.yaml
@@ -14,10 +14,24 @@ inputs:
     description: "The root directory of the Poetry project."
     required: false
     default: "."
+  install-pipx:
+    description: "Whether to ensure that pipx is installed before invoking it."
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
   steps:
+    - name: Install pipx
+      if: ${{ inputs.install-pipx == 'true' }}
+      run: |
+        sudo apt update
+        sudo apt install pipx -y
+        pipx ensurepath
+        # https://github.com/pypa/pipx/issues/853
+        virtualenv --clear /home/runner/.local/pipx/shared
+      shell: bash
+
     - name: Install Poetry ${{ inputs.poetry-version }}
       run: pipx install poetry==${{ inputs.poetry-version }}
       shell: bash

--- a/actions/python-setup-poetry/action.yaml
+++ b/actions/python-setup-poetry/action.yaml
@@ -25,6 +25,8 @@ runs:
     - name: Install pipx
       if: ${{ inputs.install-pipx == 'true' }}
       run: |
+        sudo apt update
+        sudo apt install python3-venv -y
         # Assumes Ubuntu 22.04 or below
         python3 -m pip install --user pipx
         python3 -m pipx ensurepath

--- a/docs/actions/python-setup-poetry/README.md
+++ b/docs/actions/python-setup-poetry/README.md
@@ -24,11 +24,12 @@ steps:
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-| INPUT             | TYPE   | REQUIRED | DEFAULT   | DESCRIPTION                                            |
-| ----------------- | ------ | -------- | --------- | ------------------------------------------------------ |
-| poetry-version    | string | false    | `"1.2.2"` | The Poetry version to be installed.                    |
-| python-version    | string | false    | `"3.10"`  | The Python version for the Poetry virtual environment. |
-| working-directory | string | false    | `"."`     | The root directory of the Poetry project.              |
+| INPUT             | TYPE   | REQUIRED | DEFAULT   | DESCRIPTION                                                  |
+| ----------------- | ------ | -------- | --------- | ------------------------------------------------------------ |
+| install-pipx      | string | false    | `"false"` | Whether to ensure that pipx is installed before invoking it. |
+| poetry-version    | string | false    | `"1.2.2"` | The Poetry version to be installed.                          |
+| python-version    | string | false    | `"3.10"`  | The Python version for the Poetry virtual environment.       |
+| working-directory | string | false    | `"."`     | The root directory of the Poetry project.                    |
 
 <!-- AUTO-DOC-INPUT:END -->
 


### PR DESCRIPTION
Necessary because `pipx` is not installed on all non-GitHub runners.