### PR TITLE
bump(actions): use actions that use n20

### DIFF
--- a/.github/workflows/_pre-commit-check.yaml
+++ b/.github/workflows/_pre-commit-check.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Installation
         run: |

--- a/actions/commit-and-push/action.yaml
+++ b/actions/commit-and-push/action.yaml
@@ -54,7 +54,7 @@ runs:
       shell: bash
 
     - name: Push changes
-      uses: ad-m/github-push-action@v0.6.0
+      uses: ad-m/github-push-action@v0.8.0
       with:
         github_token: ${{ inputs.github-token }}
         branch: refs/heads/${{ inputs.ref }}

--- a/actions/java-gradle-release-github/action.yaml
+++ b/actions/java-gradle-release-github/action.yaml
@@ -65,7 +65,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
 
     - name: Create Github release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2.0.4
       with:
         body_path: CHANGELOG.md
         files: "**/build/libs/*.jar"

--- a/actions/tag-and-release/action.yaml
+++ b/actions/tag-and-release/action.yaml
@@ -33,7 +33,7 @@ runs:
       shell: bash
 
     - name: Create Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2.0.4
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       with:


### PR DESCRIPTION
fixes #174
No of the listed actions had breaking changes according to the release notes:
- https://github.com/softprops/action-gh-release/releases/tag/v2.0.0
- https://github.com/ad-m/github-push-action/releases/tag/v0.8.0
- https://github.com/actions/checkout/releases/tag/v4.1.4