### PR TITLE
bump: docker publish to 1.46.3

### DIFF
--- a/.github/workflows/java-gradle-docker.yaml
+++ b/.github/workflows/java-gradle-docker.yaml
@@ -8,6 +8,11 @@ on:
         description: "Publisher to prefix Docker image."
         required: true
         type: string
+      docker-registry:
+        description: "Host where the image should be pushed to."
+        required: false
+        type: string
+        default: "docker.io"
       java-distribution:
         description: "Java distribution to be installed. (Default is microsoft)"
         required: false
@@ -147,9 +152,8 @@ jobs:
       - name: Publish tarball image
         uses: bakdata/ci-templates/actions/docker-publish@1.46.3
         with:
-          publisher: ${{ inputs.docker-publisher }}
-          username: ${{ secrets.docker-username }}
-          password: ${{ secrets.docker-password }}
+          docker-registry: ${{ inputs.docker-registry }}
+          image-namespace: ${{ inputs.docker-publisher }}
 
   release:
     name: Create Github release

--- a/.github/workflows/java-gradle-docker.yaml
+++ b/.github/workflows/java-gradle-docker.yaml
@@ -145,7 +145,7 @@ jobs:
 
     steps:
       - name: Publish tarball image
-        uses: bakdata/ci-templates/actions/docker-publish@v1.46.3
+        uses: bakdata/ci-templates/actions/docker-publish@1.46.3
         with:
           publisher: ${{ inputs.docker-publisher }}
           username: ${{ secrets.docker-username }}

--- a/.github/workflows/java-gradle-docker.yaml
+++ b/.github/workflows/java-gradle-docker.yaml
@@ -145,7 +145,7 @@ jobs:
 
     steps:
       - name: Publish tarball image
-        uses: bakdata/ci-templates/actions/docker-publish@v1.16.0
+        uses: bakdata/ci-templates/actions/docker-publish@v1.46.3
         with:
           publisher: ${{ inputs.docker-publisher }}
           username: ${{ secrets.docker-username }}

--- a/.github/workflows/java-gradle-docker.yaml
+++ b/.github/workflows/java-gradle-docker.yaml
@@ -149,6 +149,12 @@ jobs:
     needs: build-jib
 
     steps:
+      - name: Login into docker
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.docker-registry }}
+          username: ${{ secrets.docker-username }}
+          password: ${{ secrets.docker-password }}
       - name: Publish tarball image
         uses: bakdata/ci-templates/actions/docker-publish@1.46.3
         with:

--- a/docs/workflows/java-gradle-docker/README.md
+++ b/docs/workflows/java-gradle-docker/README.md
@@ -61,6 +61,7 @@ jobs:
 | INPUT                       | TYPE    | REQUIRED | DEFAULT       | DESCRIPTION                                                                                       |
 | --------------------------- | ------- | -------- | ------------- | ------------------------------------------------------------------------------------------------- |
 | docker-publisher            | string  | true     |               | Publisher to prefix Docker image.                                                                 |
+| docker-registry             | string  | false    | `"docker.io"` | Host where the image should be pushed to.                                                         |
 | gradle-cache                | boolean | false    | `true`        | Whether Gradle caching is enabled or not. (Default is true)                                       |
 | gradle-cache-read-only      | boolean | false    | `false`       | Whether Gradle caching should be read-only. Only used for build and test jobs. (Default is false) |
 | gradle-refresh-dependencies | boolean | false    | `false`       | Whether Gradle should refresh dependencies. (Default is false)                                    |


### PR DESCRIPTION
The 1.16.0 publish action does assume that images that are loaded are tagged in a certian way. This is not guaranteed anymore and the newer versions address this (i.e. just using the image name without a tag to retag, though I have no idea how docker internally chooses what image to use. Should not be an issue cuz only one image tag will be loaded anyway)

It also required the addition of the login action to facilitate auth against registries