### PR TITLE
Squashed commit of the following:

### DIFF
--- a/.github/workflows/bump-version-release.yaml
+++ b/.github/workflows/bump-version-release.yaml
@@ -13,11 +13,6 @@ on:
         required: false
         default: true
         type: boolean
-      changelog-config:
-        description: "Changelog config path."
-        required: false
-        default: ""
-        type: string
       working-directory:
         description: "Working directory containing `.bumpversion.cfg`. (Default is .)"
         required: false
@@ -57,14 +52,27 @@ jobs:
         uses: bakdata/ci-templates/actions/checkout@1.49.0
         with:
           ref: ${{ github.event.repository.default_branch }}
-          persist-credentials: false # required for pushing to protected branch later
+          persist-credentials: true # required for pushing to protected branch later
 
-      - name: Bump version
+      - name: Setup Git
+        run: |
+          git config --global user.name "${{ secrets.github-username }}"
+          git config --global user.email "${{ secrets.github-email }}"
+
+      - name: Remove snapshot suffix
         id: bump-version
-        uses: bakdata/ci-templates/actions/bump-version@v1.21.2
+        uses: bakdata/ci-templates/actions/bump-version@feat/new-bumpversion
         with:
-          release-type: ${{ inputs.release-type }}
+          release-type: "release"
           working-directory: ${{ inputs.working-directory }}
+
+      - name: Commit .bumpversion.cfg file without snapshot
+        run: |
+          git add .bumpversion.cfg
+          git commit -m "Bump version ${{ steps.bump-version.outputs.old-version }} → ${{ steps.bump-version.outputs.release-version }}"
+          git fetch origin
+          git rebase --strategy-option=theirs origin/main
+          git push --verbose
 
       - name: Create changelog
         id: build-changelog
@@ -93,3 +101,18 @@ jobs:
           github-token: ${{ secrets.github-token }}
           release-title: "${{ steps.bump-version.outputs.release-version }}"
           release-body: "${{ steps.build-changelog.outputs.single-changelog }}"
+
+      - name: Bump to next snapshot version
+        id: bump-version-snapshot
+        uses: bakdata/ci-templates/actions/bump-version@feat/new-bumpversion
+        with:
+          release-type: ${{ inputs.release-type }}
+          working-directory: ${{ inputs.working-directory }}
+
+      - name: Commit .bumpversion.cfg file new version and snapshot
+        run: |
+          git add .bumpversion.cfg
+          git commit -m "Bump version ${{ steps.bump-version.outputs.release-version }} → ${{ steps.bump-version-snapshot.outputs.release-version }}"
+          git fetch origin
+          git rebase --strategy-option=theirs origin/main
+          git push --verbose

--- a/actions/bump-version/action.yaml
+++ b/actions/bump-version/action.yaml
@@ -1,9 +1,25 @@
 name: "Bump version"
-description: "Bump version with python bump2version using .bumpversion.cfg"
+description: "Bump version with python bump-my-version using .bumpversion.cfg"
+# config example .bumpversion.cfg:
+# [bumpversion]
+# current_version = 1.0.0
+# search = version: {current_version}
+# replace = version: {new_version}
+# parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>snapshot))?
+# serialize =
+# 	{major}.{minor}.{patch}-{release}
+# 	{major}.{minor}.{patch}
+
+# [bumpversion:part:release]
+# first_value = snapshot
+# optional_value = release
+# values =
+# 	snapshot
+# 	release
 
 inputs:
   release-type:
-    description: "The type of the release (major, minor or patch)."
+    description: "The type of the release (release, major, minor or patch). Release is a special case, where the snapshot suffix is removed."
     required: true
   working-directory:
     description: "The directory containing the `.bumpversion.cfg` file."
@@ -25,20 +41,27 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up bump2version
+    - name: Set up bump-my-version
       run: |
-        pipx install bump2version
+        pipx install bump-my-version
       shell: bash
 
     - name: Bump version
       id: bump-version
       run: |
-        parameters=(--no-commit --no-tag ${{ inputs.release-type }})
-        echo "old-version=$(python -c "from configparser import ConfigParser; cfg = ConfigParser(); cfg.read('.bumpversion.cfg'); print(cfg['bumpversion']['current_version'])")" >> "$GITHUB_OUTPUT"
-        if [ -n "${{ inputs.new-version }}" ]; then
-          parameters+=(--new-version ${{ inputs.new-version }})
+        echo "old-version=$(bump-my-version show current_version | tail -1)" >> "$GITHUB_OUTPUT"
+
+        if [[ "${{ inputs.new-version }}" != "" ]]; then
+          bump-my-version --new-version ${{ inputs.new-version }}
+        else
+          bump-my-version bump ${{ inputs.release-type }}
         fi
-        bump2version "${parameters[@]}"
-        echo "new-version=$(python -c "from configparser import ConfigParser; cfg = ConfigParser(); cfg.read('.bumpversion.cfg'); print(cfg['bumpversion']['current_version'])")" >> "$GITHUB_OUTPUT"
+        echo "new-version=$(bump-my-version show current_version | tail -1)" >> "$GITHUB_OUTPUT"
+      # release: a.b.c-snapshot -> a.b.c
+      # release a.b.c -> crash
+      # major: a.b.c(-snapshot)? -> a+1.0.0-snapshot
+      # minor: a.b.c(-snapshot)? -> a.b+1.0-snapshot
+      # patch: a.b.c(-snapshot)? -> a.b.c+1-snapshot
+      # TLDR: release removes the snapshot suffix
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/actions/changelog-generate/action.yaml
+++ b/actions/changelog-generate/action.yaml
@@ -13,6 +13,14 @@ inputs:
     description: Path to the changelog file in the GitHub repository
     required: false
     default: "CHANGELOG.md"
+  checkout:
+    description: "Whether to checkout the repository or not."
+    required: false
+    default: "false"
+  clean:
+    description: "Clean the repository before running the action."
+    required: false
+    default: false
 
 outputs:
   merged-changelog:
@@ -26,9 +34,11 @@ runs:
   using: "composite"
   steps:
     - name: Check out repository
-      uses: bakdata/ci-templates/actions/checkout@1.49.0
+      if: ${{ inputs.checkout }}
+      uses: bakdata/ci-templates/actions/checkout@tiedemann/changelog-action-dont-clean
       with:
         fetch-depth: 0
+        clean: ${{ inputs.clean }}
     - name: Get config path
       id: get-config-path
       run: |

--- a/actions/checkout/action.yaml
+++ b/actions/checkout/action.yaml
@@ -29,6 +29,10 @@ inputs:
     description: "Whether to checkout submodules: `true` to checkout submodules or `recursive` to recursively checkout submodules."
     required: false
     default: "false"
+  clean:
+    description: "Clean the repository before running the action."
+    required: false
+    default: "true"
 
 outputs:
   lfs-cache-hit:
@@ -46,6 +50,7 @@ runs:
         persist-credentials: ${{ inputs.persist-credentials }}
         submodules: ${{ inputs.submodules }}
         fetch-depth: ${{ inputs.fetch-depth }}
+        clean: ${{ inputs.clean }}
 
     - name: Create LFS file list
       if: ${{ inputs.lfs == 'true'}}

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -31,7 +31,7 @@ runs:
         workload_identity_provider: ${{ inputs.workload-identity-provider }}
         service_account: ${{ inputs.gke-service-account }}
     - id: "parse_secrets"
-      uses: "bakdata/ci-templates/actions/parse-secrets-definitions@1.48.0"
+      uses: "bakdata/ci-templates/actions/gcp-gsm-parse-secrets@tiedemann/changelog-action-dont-clean"
       with:
         project_name: ${{ inputs.gke-project-name }}
         secrets_list: ${{ inputs.secrets-to-inject }}

--- a/docs/actions/bump-version/README.md
+++ b/docs/actions/bump-version/README.md
@@ -38,11 +38,11 @@ steps:
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-| INPUT             | TYPE   | REQUIRED | DEFAULT | DESCRIPTION                                           |
-| ----------------- | ------ | -------- | ------- | ----------------------------------------------------- |
-| new-version       | string | false    |         |                                                       |
-| release-type      | string | true     |         | The type of the release (major, minor or patch).      |
-| working-directory | string | false    | `"."`   | The directory containing the `.bumpversion.cfg` file. |
+| INPUT             | TYPE   | REQUIRED | DEFAULT | DESCRIPTION                                                                                                                |
+| ----------------- | ------ | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------- |
+| new-version       | string | false    |         |                                                                                                                            |
+| release-type      | string | true     |         | The type of the release (release, major, minor or patch). Release is a special case, where the snapshot suffix is removed. |
+| working-directory | string | false    | `"."`   | The directory containing the `.bumpversion.cfg` file.                                                                      |
 
 <!-- AUTO-DOC-INPUT:END -->
 

--- a/docs/actions/changelog-generate/README.md
+++ b/docs/actions/changelog-generate/README.md
@@ -89,6 +89,8 @@ steps:
 | INPUT          | TYPE   | REQUIRED | DEFAULT          | DESCRIPTION                                         |
 | -------------- | ------ | -------- | ---------------- | --------------------------------------------------- |
 | changelog-file | string | false    | `"CHANGELOG.md"` | Path to the changelog file in the GitHub repository |
+| checkout       | string | false    | `"false"`        | Whether to checkout the repository or not.          |
+| clean          | string | false    | `"false"`        | Clean the repository before running the action.     |
 | github-token   | string | true     |                  | The GitHub token for committing the changes.        |
 | tag            | string | true     |                  | Version after bump                                  |
 

--- a/docs/actions/checkout/README.md
+++ b/docs/actions/checkout/README.md
@@ -35,6 +35,7 @@ steps:
 | INPUT               | TYPE   | REQUIRED | DEFAULT                      | DESCRIPTION                                                                                                      |
 | ------------------- | ------ | -------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | cache               | string | false    | `"true"`                     | Describes if the repository is using any LFS files                                                               |
+| clean               | string | false    | `"true"`                     | Clean the repository before running the action.                                                                  |
 | fetch-depth         | string | false    | `"1"`                        | Number of commits to fetch. 0 indicates all history for all branches and tags                                    |
 | lfs                 | string | false    | `"false"`                    | Describes if the repository is using any LFS files                                                               |
 | persist-credentials | string | false    | `"true"`                     | Whether to configure the token or SSH key with the local git config                                              |

--- a/docs/workflows/bump-version-release/README.md
+++ b/docs/workflows/bump-version-release/README.md
@@ -64,7 +64,6 @@ jobs:
 | INPUT             | TYPE    | REQUIRED | DEFAULT | DESCRIPTION                                                     |
 | ----------------- | ------- | -------- | ------- | --------------------------------------------------------------- |
 | changelog         | boolean | false    | `true`  | Create changelog for release.                                   |
-| changelog-config  | string  | false    |         | Changelog config path.                                          |
 | release-type      | string  | true     |         | Scope of the release (major, minor or patch).                   |
 | working-directory | string  | false    | `"."`   | Working directory containing `.bumpversion.cfg`. (Default is .) |
 


### PR DESCRIPTION
commit 3fc6d362b2782d3eb7c2aef46fd05036979150b6
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Wed Nov 13 14:46:55 2024 +0100

    found it :3

commit 3a157421096a9162d7338a1a9ad5aaf2b0f834d6
Merge: 6c611e9 cb23302
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Wed Nov 13 14:38:29 2024 +0100

    Merge branch 'main' into tiedemann/changelog-action-dont-clean

commit 6c611e90ec35a2f2c32c472b8df0348337f3233d
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Wed Nov 13 14:29:31 2024 +0100

    fix symlinks

commit 9bdd0554b865f8cb40eb636f639dd5c7dc6a5b0b
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Wed Nov 13 14:28:28 2024 +0100

    rm symlinks

commit 1ef4c0263dd5b2449bda8dc6e383e17a94b77b69
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Wed Nov 13 14:27:05 2024 +0100

    remove symlinks

commit 933cb88d066590d25ba4ede8baebebb4d8a8900a
Author: Yannick Röder <yannick.roeder@bakdata.com>
Date:   Wed Nov 13 14:04:24 2024 +0100

    Move checkout condition to changelog action

commit 1efda99e1044f0e1a189598d37ee2fa5d3979aeb
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Wed Nov 13 11:49:20 2024 +0100

    feat: add input to skip checkout based on input flag

commit f82dac8eb24b88c1e14040d67f61e8392d49f366
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Nov 12 17:06:26 2024 +0100

    fix: use proper branch

commit 9c0658e3f792be36a2963b3d98782d019f14e653
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Nov 12 16:56:51 2024 +0100

    fix: add the input to the changelog action aswell

commit 178c7e264ac7b271a356da0c232882aba82508a8
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Nov 12 16:55:28 2024 +0100

    fix: make the clean step optional

commit 0207242707c6ce2ede051adc636ef671f96da961
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Nov 12 16:42:41 2024 +0100

    fix: fixes deletion of uncommited files in the current working directory

commit e163e0bc560f058dc873fba2031783061716a537
Author: bakdata-bot <bakdata-bot@users.noreply.github.com>
Date:   Mon Nov 11 16:30:31 2024 +0000

    Bump version 1.48.0 → 1.49.0

commit 15ad433a9c61cc583404acf7eff2c5501b05a9b7
Author: Yannick Röder <33963579+yannick-roeder@users.noreply.github.com>
Date:   Mon Nov 11 17:29:57 2024 +0100

    Revert pre-version bump in release workflow (#217)

commit f9ff265e44e0b8e6884f0ed26581af4c4533507c
Author: Yannick Röder <33963579+yannick-roeder@users.noreply.github.com>
Date:   Mon Nov 11 15:53:04 2024 +0100

    Update deprecated NodeJS actions (#215)

commit 9ac2b9fff5051bd0d8a8c906fe646cb34fac6485
Author: Yannick Röder <33963579+yannick-roeder@users.noreply.github.com>
Date:   Mon Nov 11 12:46:53 2024 +0100

    Update Python versions of Poetry setup test (#216)

commit 6318b885ac7283fac961688a8c8a49d4e6e33142
Author: bakdata-bot <bakdata-bot@users.noreply.github.com>
Date:   Mon Nov 11 09:09:46 2024 +0000

    Bump version 1.47.0 → 1.48.0

commit 07b3b82013fc02aefdfc1d19b7d8055f6132b01a
Author: DerTiedemann <jan.max.tiedemann@bakdata.com>
Date:   Mon Nov 11 10:08:45 2024 +0100

    feat: initial version of gsm secret loader (#213)

    This PR is the basis for the workload identity integration for GH
    workflows.
    Based on context it will load all secrets that are specified, transform
    their names to screaming snake case and export them.

    There are some tests and one is failing and i dont know why. All basic
    usecases work though.

    ---------

    Co-authored-by: Yannick Röder <33963579+yannick-roeder@users.noreply.github.com>

commit 5d0791b1a750c2d2f7fb3cbd9ee31a6637420cf4
Author: DerTiedemann <jan.max.tiedemann@bakdata.com>
Date:   Thu Nov 7 10:07:31 2024 +0100

    Adapt poetry release workflow for new changelog action (#214)

commit 994a5e8d85c2e0fdaad5e047adc60f273c21b34e
Author: DerTiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Nov 5 09:18:06 2024 +0100

    Feat: New changelog generator (#205)

    New changelog generator: https://git-cliff.org/
    This action updated replaces the previous generator with the
    aforementioned tool.

    All existing functionality has been preserved and some new things have
    been added, most notably the first contribution mention. The action will
    check of there is a `cliff.toml` present in the current repo and if not
    use the default that is present inside of this repo. Custom configs are
    sometimes required to filter out commits that dont contain meaningful
    changes like version bumps. An example of how this could look for
    streams-bootstrap:
    ```toml
    commit_parsers = [
      { message = "^\\[Gradle Release Plugin\\]", skip = true },
      { message = "^Changelog for version .*", skip = true },
    ]
    ```

    Which turns changelogs that look like this:
    2024-06-12

    * [Gradle Release Plugin] - new version commit: '2.22.2-SNAPSHOT'. by
    @bakdata-bot

    * Changelog for version 2.22.1 by @bakdata-bot

    * Add dynamic application.server config to streams app chart by
    @philipp94831 in
    [#214](https://github.com/bakdata/streams-bootstrap/pull/214)

    * [Gradle Release Plugin] - pre tag commit:  '2.23.0'. by @bakdata-bot

    **Full Changelog**:
    https://github.com/bakdata/streams-bootstrap/compare/2.22.1...2.23.0

    into this:
    2024-06-12

    * Add dynamic application.server config to streams app chart by
    @philipp94831 in
    [#214](https://github.com/bakdata/streams-bootstrap/pull/214)

    **Full Changelog**:
    https://github.com/bakdata/streams-bootstrap/compare/2.22.1...2.23.0

    <hr>

    For more config options have a look at the docs, this thing is pretty
    powerful. Let me know what you think.

commit b7da2581c1c5293f5937f60f7fb34d2d732b04b7
Author: bakdata-bot <bakdata-bot@users.noreply.github.com>
Date:   Mon Sep 2 07:56:56 2024 +0000

    Bump version 1.46.10 → 1.47.0

commit e4ec4a2e20848501d44598dda5af7892c649ac1a
Author: bakdata-bot <bakdata-bot@users.noreply.github.com>
Date:   Mon Sep 2 07:54:20 2024 +0000

    Bump version 1.46.9 → 1.46.10

commit cbee7aac367f0abb7f9350ce7f04a747ebf6b509
Author: yordanovsstoyan <105302626+yordanovsstoyan@users.noreply.github.com>
Date:   Mon Sep 2 10:53:44 2024 +0300

    Add Additional Flags input for action-lint action (#211)

commit 7b274ead861c856db36a68b32c3b9c7fb69ea6a3
Author: bakdata-bot <bakdata-bot@users.noreply.github.com>
Date:   Mon Aug 26 07:57:45 2024 +0000

    Bump version 1.46.8 → 1.46.9

commit 270ac8a57699737d9644f2389240400529c1b85e
Author: yordanovsstoyan <105302626+yordanovsstoyan@users.noreply.github.com>
Date:   Mon Aug 26 10:57:18 2024 +0300

    Output Image Tag in java-gradle-build-jib Action (#210)

commit 651ae5d156b528a85b708af96148588d35c2d109
Author: bakdata-bot <bakdata-bot@users.noreply.github.com>
Date:   Mon Aug 19 07:54:43 2024 +0000

    Bump version 1.46.7 → 1.46.8

commit 2320bcede7720d8d0c4243b179668521b11000a0
Author: Philipp Schirmer <philipp.schirmer@bakdata.com>
Date:   Mon Aug 19 09:54:17 2024 +0200

    Fix maven setup action (#209)

commit f001d66737d40e9150f78fdd87d8fa11ad9a6575
Author: DerTiedemann <jan.max.tiedemann@bakdata.com>
Date:   Thu Aug 15 10:15:12 2024 +0200

    tiedemann/bump java build actions (#202)

    I just bumped these to the latest vesion as i though this would fix my
    issue, i think it can go upsteam anyway.

commit 9c0667c28e7e0e845fbbcdf7df75f47fdcf6b2ab
Author: bakdata-bot <bakdata-bot@users.noreply.github.com>
Date:   Thu Aug 15 07:50:38 2024 +0000

    Bump version 1.46.6 → 1.46.7

commit 2d1eacc9a2b942b90950539119bb00171378dda5
Author: yordanovsstoyan <105302626+yordanovsstoyan@users.noreply.github.com>
Date:   Thu Aug 15 10:50:10 2024 +0300

    Fix tagging java-gradle-build-jib action (#208)

    Co-authored-by: Yannick Röder <33963579+yannick-roeder@users.noreply.github.com>

commit 892c70431f536b64dbe99e021aac8e9b366afe3b
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Sep 3 22:38:06 2024 +0200

    fix: make commit message correct

commit c3668a6b91f023169c0eb5d71002d11e8edb6ca2
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Sep 3 22:25:11 2024 +0200

    fix: persist credentials

commit 1800eff5a01aa607270de78d5fa1859a79687b87
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Sep 3 22:19:28 2024 +0200

    fix: try using normal git commits

commit cb5bc5b166ba64fbd6f5eec56cd1ad953e482afb
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Sep 3 20:46:10 2024 +0200

    fix: try to use checkout to pull the latest changes

commit 5926df297099ea69d18bc26402a82b31d37bdcbc
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Sep 3 20:39:29 2024 +0200

    fix: add git config

commit e70c241bb35985e9786dbed241b056fb47802d62
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Sep 3 20:36:45 2024 +0200

    fix: add pull command

commit 78af69603c909b4ed9d18dc5d1929d3073d94c79
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Sep 3 10:19:44 2024 +0200

    fix: try with push

commit 9365e3d2c156b6e4536713c5b0825b06f2a0c6f6
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Sep 3 10:13:26 2024 +0200

    fix: add git username + email

commit f1ec7de669f5b3a7e799f77559dacd8c6f303d85
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Sep 3 10:10:16 2024 +0200

    fix: try single push

commit e091bd61227be3fbc629b705022c91c98608abc3
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Sep 3 10:06:47 2024 +0200

    test

commit e1702734d3869c46731a364da748c30a0702d308
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Sep 3 10:01:55 2024 +0200

    fix: use different commit message for second commit

commit 7df58c7353b1f30102e5920401c6159de647b104
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Sep 3 09:49:12 2024 +0200

    fix: new chamgelog action

commit 332f3eb59c106ec62f7f8ce90b0bc45f69131f6e
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Sep 3 07:30:54 2024 +0200

    fix: proper outpuit

commit e58ea38d3f5e8c95fa536132928d93a3d2c87795
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Sep 3 07:29:35 2024 +0200

    fix: only use bump

commit f1bc6f089fc7ac15ae3c01220d1b509c5232b24c
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Sep 3 07:28:20 2024 +0200

    fix: remove deprecated flags

commit e592eeca3b5a4e2756bc84dbd4b8870a9faf559f
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Sep 3 07:27:10 2024 +0200

    fix: make sure there is an empty string for the comparison

commit eda6cffa2af010da45942209c197fa8e487af0e5
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Mon Sep 2 08:30:22 2024 +0200

    Revert "chore: prep new version for release"

    This reverts commit c12b09049fb81c2b76d04fe3b27b94a0675f2c66.

commit c12b09049fb81c2b76d04fe3b27b94a0675f2c66
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Mon Sep 2 08:29:27 2024 +0200

    chore: prep new version for release

commit fbfe193d7efd202ae5581954972d3d8235178360
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Thu Aug 8 07:06:32 2024 +0200

    fix: add missing inline bash operator

commit 43f89231d557bcdb251d7bc8d21a87ddf0fa76e8
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Aug 6 03:04:25 2024 +0200

    lint: fix actionlint complaints

commit 5eea4973405ccd0564d9661ad3c1a583dbcb4574
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Aug 6 03:01:32 2024 +0200

    fix:
    - use bump-my-version instead of deprecated bump2version
    - merge snapshot action into bump action via parameter
    - WARN: requires special config - example given

commit a2a3e0cd402074d3fbb43d997ad8877a6fdfd3b0
Author: Jan Max Tiedemann <jan.max.tiedemann@bakdata.com>
Date:   Tue Aug 6 02:59:01 2024 +0200

    fix: remove redundant action

commit 2c7f4c01a835d5d840b45373cbea1b051fee5c44
Author: yordanovsstoyan <stoyan.yordanov@bakdata.com>
Date:   Thu Nov 9 12:59:54 2023 +0200

    changes

commit 7a76951b01d25146c9a4774f92916b0bb5549e2d
Author: yordanovsstoyan <stoyan.yordanov@bakdata.com>
Date:   Wed Oct 4 10:41:43 2023 +0300

    remove-variable

commit 0b030f3b95785e921775781dcb8abfa8ec6b9d72
Author: yordanovsstoyan <stoyan.yordanov@bakdata.com>
Date:   Wed Oct 4 10:39:41 2023 +0300

    test

commit d0d3c6076ec5784f7b5f2f7eab2996a94637142c
Author: yordanovsstoyan <stoyan.yordanov@bakdata.com>
Date:   Tue Oct 3 13:08:49 2023 +0300

    test

commit 54c86f74d7df4479c11d86af2d8277ec9dbc8a22
Author: yordanovsstoyan <stoyan.yordanov@bakdata.com>
Date:   Tue Oct 3 13:00:37 2023 +0300

    test

commit 78b45d4fc1674515c942d444ce252270dc566fab
Author: yordanovsstoyan <stoyan.yordanov@bakdata.com>
Date:   Tue Oct 3 12:58:45 2023 +0300

    reboot

commit 99c497133d26e64a35057c63f96b3dc3ac4b7445
Author: stoyan.yordanov <stoyan.yordanov@bakdata.com>
Date:   Thu Aug 31 09:23:26 2023 +0300

    commit-message

commit 82db094b438be36bec2b93bae0d94bb739ca0737
Author: stoyan.yordanov <stoyan.yordanov@bakdata.com>
Date:   Tue Aug 29 15:25:51 2023 +0300

    commit-message

commit a0416c6bd531f8e2dfb8948e88d34dce80ebc549
Author: stoyan.yordanov <stoyan.yordanov@bakdata.com>
Date:   Tue Aug 29 13:24:15 2023 +0300

    commit-message

commit 0375c17513c8ee9b332adf81f0c9d63757eab888
Author: stoyan.yordanov <stoyan.yordanov@bakdata.com>
Date:   Tue Aug 29 12:39:27 2023 +0300

    commit-message
