### PR TITLE
Fix broken outputs from GSM actions

### DIFF
--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -31,7 +31,7 @@ runs:
         workload_identity_provider: ${{ inputs.workload-identity-provider }}
         service_account: ${{ inputs.gke-service-account }}
     - id: "parse_secrets"
-      uses: "bakdata/ci-templates/actions/parse-secrets-definitions@1.49.0"
+      uses: "bakdata/ci-templates/actions/gcp-gsm-parse-secerts@1.49.0"
       with:
         project_name: ${{ inputs.gke-project-name }}
         secrets_list: ${{ inputs.secrets-to-inject }}

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -40,6 +40,9 @@ runs:
       with:
         secrets: ${{ steps.parse_secrets.outputs.secrets-list }}
         export_to_environment: ${{ inputs.export-to-environment }}
+    - name: "test"
+      run: |
+        echo '${{ toJSON(steps.secrets.outputs) }}'
     - name: "Set outputs"
       uses: "actions/github-script@v7"
       with:

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -17,10 +17,10 @@ inputs:
     description: "Export secrets to environment"
     required: false
     default: true
-outputs:
-  secret-names:
-    description: "Comma-separated list of secret names"
-    value: ${{ steps.parse_secrets.outputs.secret-names }}
+# outputs:
+#   secret-names:
+#     description: "Comma-separated list of secret names"
+#     value: ${{ steps.parse_secrets.outputs.secret-names }}
 runs:
   using: "composite"
   steps:

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -17,10 +17,10 @@ inputs:
     description: "Export secrets to environment"
     required: false
     default: true
-# outputs:
-#   secret-names:
-#     description: "Comma-separated list of secret names"
-#     value: ${{ steps.parse_secrets.outputs.secret-names }}
+outputs:
+  secret-json-string:
+    description: "JSON string with all secrets"
+    value: ${{ toJSON(steps.secrets.outputs) }}
 runs:
   using: "composite"
   steps:
@@ -40,18 +40,3 @@ runs:
       with:
         secrets: ${{ steps.parse_secrets.outputs.secrets-list }}
         export_to_environment: ${{ inputs.export-to-environment }}
-    - name: "test"
-      shell: bash
-      run: |
-        echo '${{ toJSON(steps.secrets.outputs) }}'
-        echo "console.log('${{ toJSON(steps.secrets.outputs) }}')"
-        echo "TEST=SOMEHTHING" >> "$GITHUB_OUTPUT"
-    # - name: "Set outputs"
-    #   uses: "actions/github-script@v7"
-    #   with:
-    #     script: |
-    #       let secrets = ${{ toJSON(steps.secrets.outputs) }}
-    #       for (const [key, value] of Object.entries(secrets)) {
-    #         core.setOutput(key, value);
-    #         console.log(`Set output ${key}`);
-    #       }

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -20,7 +20,7 @@ inputs:
 outputs:
   secrets:
     description: "Secrets loaded from Secret Manager"
-    value: ${{ steps.secrets.outputs.secrets }}
+    value: ${{ toJSON(steps.secrets.outputs.secrets) }}
 runs:
   using: "composite"
   steps:

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -41,6 +41,7 @@ runs:
         secrets: ${{ steps.parse_secrets.outputs.secrets-list }}
         export_to_environment: ${{ inputs.export-to-environment }}
     - name: "test"
+      shell: bash
       run: |
         echo '${{ toJSON(steps.secrets.outputs) }}'
     - name: "Set outputs"

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -49,3 +49,4 @@ runs:
       with:
         script: |
           console.log('test')
+          console.log('${{ toJSON(steps.secrets.outputs) }')

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -50,4 +50,5 @@ runs:
       with:
         script: |
           console.log('test')
-          console.log('${{ toJSON(steps.secrets.outputs) }}')
+          let a = ${{ toJSON(steps.secrets.outputs) }}
+          console.log(a)

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -48,7 +48,7 @@ runs:
       uses: "actions/github-script@v7"
       with:
         script: |
-          console.log('${{ toJSON(steps.secrets.outputs) }}');
+          console.log('test');
           // const secrets = JSON.parse('${{ toJSON(steps.secrets.outputs) }}');
           // for (const [key, value] of Object.entries(secrets)) {
           //    core.setOutput(key, value);

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -48,7 +48,8 @@ runs:
       uses: "actions/github-script@v7"
       with:
         script: |
-          const secrets = JSON.parse('${{ toJSON(steps.secrets.outputs) }}');
-          for (const [key, value] of Object.entries(secrets)) {
-            core.setOutput(key, value);
-          }
+          console.log('${{ toJSON(steps.secrets.outputs) }}');
+          // const secrets = JSON.parse('${{ toJSON(steps.secrets.outputs) }}');
+          // for (const [key, value] of Object.entries(secrets)) {
+          //    core.setOutput(key, value);
+          // }

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -49,4 +49,4 @@ runs:
       with:
         script: |
           console.log('test')
-          console.log('${{ toJSON(steps.secrets.outputs) }')
+          console.log('${{ toJSON(steps.secrets.outputs) }}')

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -52,4 +52,5 @@ runs:
           let secrets = ${{ toJSON(steps.secrets.outputs) }}
           for (const [key, value] of Object.entries(secrets)) {
             core.setOutput(key, value);
+            console.log(`Set output ${key}`);
           }

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -44,6 +44,7 @@ runs:
       shell: bash
       run: |
         echo '${{ toJSON(steps.secrets.outputs) }}'
+        echo "console.log('${{ toJSON(steps.secrets.outputs) }}')"
     - name: "Set outputs"
       uses: "actions/github-script@v7"
       with:

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -31,7 +31,7 @@ runs:
         workload_identity_provider: ${{ inputs.workload-identity-provider }}
         service_account: ${{ inputs.gke-service-account }}
     - id: "parse_secrets"
-      uses: "bakdata/ci-templates/actions/gcp-gsm-parse-secerts@tiedemann/gsm-object-outputs-fix"
+      uses: "bakdata/ci-templates/actions/gcp-gsm-parse-secrets@tiedemann/gsm-object-outputs-fix"
       with:
         project_name: ${{ inputs.gke-project-name }}
         secrets_list: ${{ inputs.secrets-to-inject }}

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -20,7 +20,7 @@ inputs:
 outputs:
   secrets:
     description: "Secrets loaded from Secret Manager"
-    value: ${{ steps.secrets.outputs }}
+    value: ${{ toJSON(steps.secrets.outputs)}}
 runs:
   using: "composite"
   steps:

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -45,12 +45,13 @@ runs:
       run: |
         echo '${{ toJSON(steps.secrets.outputs) }}'
         echo "console.log('${{ toJSON(steps.secrets.outputs) }}')"
-    - name: "Set outputs"
-      uses: "actions/github-script@v7"
-      with:
-        script: |
-          let secrets = ${{ toJSON(steps.secrets.outputs) }}
-          for (const [key, value] of Object.entries(secrets)) {
-            core.setOutput(key, value);
-            console.log(`Set output ${key}`);
-          }
+        echo "TEST=SOMEHTHING" >> "$GITHUB_OUTPUT"
+    # - name: "Set outputs"
+    #   uses: "actions/github-script@v7"
+    #   with:
+    #     script: |
+    #       let secrets = ${{ toJSON(steps.secrets.outputs) }}
+    #       for (const [key, value] of Object.entries(secrets)) {
+    #         core.setOutput(key, value);
+    #         console.log(`Set output ${key}`);
+    #       }

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -49,6 +49,7 @@ runs:
       uses: "actions/github-script@v7"
       with:
         script: |
-          console.log('test')
-          let a = ${{ toJSON(steps.secrets.outputs) }}
-          console.log(a)
+          let secrets = ${{ toJSON(steps.secrets.outputs) }}
+          for (const [key, value] of Object.entries(secrets)) {
+            core.setOutput(key, value);
+          }

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -20,7 +20,7 @@ inputs:
 outputs:
   secrets:
     description: "Secrets loaded from Secret Manager"
-    value: ${{ toJSON(steps.secrets.outputs.secrets) }}
+    value: ${{ steps.secrets.outputs }}
 runs:
   using: "composite"
   steps:

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -18,9 +18,9 @@ inputs:
     required: false
     default: true
 outputs:
-  secrets:
-    description: "Secrets loaded from Secret Manager"
-    value: ${{ toJSON(steps.secrets.outputs)}}
+  secret-names:
+    description: "Comma-separated list of secret names"
+    value: ${{ steps.parse_secrets.outputs.secret-names }}
 runs:
   using: "composite"
   steps:
@@ -40,3 +40,8 @@ runs:
       with:
         secrets: ${{ steps.parse_secrets.outputs.secrets-list }}
         export_to_environment: ${{ inputs.export-to-environment }}
+    - name: "Set outputs"
+      run: |
+        for secret in $(echo "${{ steps.parse_secrets.outputs.secret-names }}" | sed "s/,/ /g"); do
+          echo "${secret}=${{ steps.secrets.outputs.${secret} }}" >> $GITHUB_OUTPUT
+        done

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -41,7 +41,10 @@ runs:
         secrets: ${{ steps.parse_secrets.outputs.secrets-list }}
         export_to_environment: ${{ inputs.export-to-environment }}
     - name: "Set outputs"
-      run: |
-        for secret in $(echo "${{ steps.parse_secrets.outputs.secret-names }}" | sed "s/,/ /g"); do
-          echo "${secret}=${{ steps.secrets.outputs.${secret} }}" >> $GITHUB_OUTPUT
-        done
+      uses: "actions/github-script@v7"
+      with:
+        script: |
+          const secrets = JSON.parse('${{ toJSON(steps.secrets.outputs) }}');
+          for (const [key, value] of Object.entries(secrets)) {
+            core.setOutput(key, value);
+          }

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -31,7 +31,7 @@ runs:
         workload_identity_provider: ${{ inputs.workload-identity-provider }}
         service_account: ${{ inputs.gke-service-account }}
     - id: "parse_secrets"
-      uses: "bakdata/ci-templates/actions/gcp-gsm-parse-secerts@1.49.0"
+      uses: "bakdata/ci-templates/actions/gcp-gsm-parse-secerts@tiedemann/gsm-object-outputs-fix"
       with:
         project_name: ${{ inputs.gke-project-name }}
         secrets_list: ${{ inputs.secrets-to-inject }}

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -49,7 +49,3 @@ runs:
       with:
         script: |
           console.log('test')
-          // const secrets = JSON.parse('${{ toJSON(steps.secrets.outputs) }}');
-          // for (const [key, value] of Object.entries(secrets)) {
-          //    core.setOutput(key, value);
-          // }

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -31,7 +31,7 @@ runs:
         workload_identity_provider: ${{ inputs.workload-identity-provider }}
         service_account: ${{ inputs.gke-service-account }}
     - id: "parse_secrets"
-      uses: "bakdata/ci-templates/actions/parse-secrets-definitions@1.48.0"
+      uses: "bakdata/ci-templates/actions/parse-secrets-definitions@1.49.0"
       with:
         project_name: ${{ inputs.gke-project-name }}
         secrets_list: ${{ inputs.secrets-to-inject }}

--- a/actions/gcp-gsm-load-secrets/action.yaml
+++ b/actions/gcp-gsm-load-secrets/action.yaml
@@ -48,7 +48,7 @@ runs:
       uses: "actions/github-script@v7"
       with:
         script: |
-          console.log('test');
+          console.log('test')
           // const secrets = JSON.parse('${{ toJSON(steps.secrets.outputs) }}');
           // for (const [key, value] of Object.entries(secrets)) {
           //    core.setOutput(key, value);

--- a/actions/gcp-gsm-parse-secrets/Dockerfile
+++ b/actions/gcp-gsm-parse-secrets/Dockerfile
@@ -6,9 +6,10 @@ ENV POETRY_NO_INTERACTION=1 \
     POETRY_VIRTUALENVS_CREATE=1 \
     POETRY_CACHE_DIR=/tmp/poetry_cache
 
-WORKDIR /app
+WORKDIR /github/workspace
 COPY pyproject.toml poetry.lock ./
 COPY main.py ./
 RUN poetry install --no-root && rm -rf $POETRY_CACHE_DIR
 
-CMD ["poetry","run","python", "/app/main.py"]
+CMD ["poetry","run","python", "main.py"]
+# CMD ["pwd"]

--- a/actions/gcp-gsm-parse-secrets/Dockerfile
+++ b/actions/gcp-gsm-parse-secrets/Dockerfile
@@ -10,5 +10,5 @@ COPY pyproject.toml poetry.lock ./
 COPY main.py ./
 RUN poetry install --no-root && rm -rf $POETRY_CACHE_DIR
 
-CMD ["poetry","run","python", "main.py"]
-# CMD ["pwd"]
+# CMD ["poetry","run","python", "main.py"]
+CMD ["pwd", "&&", "ls", "-la"]

--- a/actions/gcp-gsm-parse-secrets/Dockerfile
+++ b/actions/gcp-gsm-parse-secrets/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3-slim AS builder
-WORKDIR /github/workspace
+WORKDIR /action/workspace/
 
 RUN pip install poetry==1.8.2
 
@@ -8,9 +8,9 @@ ENV POETRY_NO_INTERACTION=1 \
     POETRY_VIRTUALENVS_CREATE=1 \
     POETRY_CACHE_DIR=/tmp/poetry_cache
 
-COPY pyproject.toml poetry.lock ./
-COPY main.py ./
+COPY pyproject.toml poetry.lock /action/workspace/
+COPY main.py /action/workspace/
 RUN poetry install --no-root && rm -rf $POETRY_CACHE_DIR
 
-# CMD ["poetry","run","python", "main.py"]
-CMD ["bash", "-c", "pwd && ls -la"]
+CMD ["poetry","run","python", "/action/workspace/main.py"]
+# CMD ["bash", "-c", "pwd && ls -la"]

--- a/actions/gcp-gsm-parse-secrets/Dockerfile
+++ b/actions/gcp-gsm-parse-secrets/Dockerfile
@@ -11,16 +11,4 @@ COPY pyproject.toml poetry.lock ./
 COPY main.py ./
 RUN poetry install --no-root && rm -rf $POETRY_CACHE_DIR
 
-# A distroless container image with Python and some basics like SSL certificates
-# https://github.com/GoogleContainerTools/dis/i/itroless
-FROM gcr.io/distroless/python3-debian12
-
-ENV VIRTUAL_ENV=/app/.venv \
-    PATH="/app/.venv/bin:$PATH"
-
-COPY --from=builder /app /app
-COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
-
-WORKDIR /app
-ENV PYTHONPATH /app
-CMD ["/app/main.py"]
+CMD ["poetry","run","python", "/app/main.py"]

--- a/actions/gcp-gsm-parse-secrets/Dockerfile
+++ b/actions/gcp-gsm-parse-secrets/Dockerfile
@@ -6,7 +6,6 @@ ENV POETRY_NO_INTERACTION=1 \
     POETRY_VIRTUALENVS_CREATE=1 \
     POETRY_CACHE_DIR=/tmp/poetry_cache
 
-WORKDIR /github/workspace
 COPY pyproject.toml poetry.lock ./
 COPY main.py ./
 RUN poetry install --no-root && rm -rf $POETRY_CACHE_DIR

--- a/actions/gcp-gsm-parse-secrets/Dockerfile
+++ b/actions/gcp-gsm-parse-secrets/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3-slim AS builder
+WORKDIR /github/workspace
+
 RUN pip install poetry==1.8.2
 
 ENV POETRY_NO_INTERACTION=1 \

--- a/actions/gcp-gsm-parse-secrets/Dockerfile
+++ b/actions/gcp-gsm-parse-secrets/Dockerfile
@@ -12,5 +12,5 @@ COPY pyproject.toml poetry.lock /action/workspace/
 COPY main.py /action/workspace/
 RUN poetry install --no-root && rm -rf $POETRY_CACHE_DIR
 
-CMD ["poetry","run","python", "/action/workspace/main.py"]
-# CMD ["bash", "-c", "pwd && ls -la"]
+# CMD ["poetry","run","python", "/action/workspace/main.py"]
+CMD ["bash", "-c", "pwd && ls -la /action/workspace && poetry run python /action/workspace/main.py"]

--- a/actions/gcp-gsm-parse-secrets/Dockerfile
+++ b/actions/gcp-gsm-parse-secrets/Dockerfile
@@ -12,5 +12,4 @@ COPY pyproject.toml poetry.lock /action/workspace/
 COPY main.py /action/workspace/
 RUN poetry install --no-root && rm -rf $POETRY_CACHE_DIR
 
-# CMD ["poetry","run","python", "/action/workspace/main.py"]
-CMD ["bash", "-c", "pwd && ls -la /action/workspace && poetry run python /action/workspace/main.py"]
+CMD ["bash", "-c", "cd /action/workspace && poetry run python main.py"]

--- a/actions/gcp-gsm-parse-secrets/Dockerfile
+++ b/actions/gcp-gsm-parse-secrets/Dockerfile
@@ -11,4 +11,4 @@ COPY main.py ./
 RUN poetry install --no-root && rm -rf $POETRY_CACHE_DIR
 
 # CMD ["poetry","run","python", "main.py"]
-CMD ["pwd", "&&", "ls", "-la"]
+CMD ["pwd"]

--- a/actions/gcp-gsm-parse-secrets/Dockerfile
+++ b/actions/gcp-gsm-parse-secrets/Dockerfile
@@ -11,4 +11,4 @@ COPY main.py ./
 RUN poetry install --no-root && rm -rf $POETRY_CACHE_DIR
 
 # CMD ["poetry","run","python", "main.py"]
-CMD ["pwd"]
+CMD ["bash", "-c", "pwd && ls -la"]

--- a/actions/gcp-gsm-parse-secrets/main.py
+++ b/actions/gcp-gsm-parse-secrets/main.py
@@ -55,16 +55,16 @@ def main(
     # Deduplicate the input secrets
     input_secrets = set(input_secrets.splitlines())
 
-    output = ""
+    output = []
     parsed_secret_names = []
     for secret in input_secrets:
-        parsed_secret, parsed_secret_name = (
-            parse_secret(secret, gcp_project, github_output_delimter) + "\n"
+        parsed_secret, parsed_secret_name = parse_secret(
+            secret, gcp_project, github_output_delimter
         )
-        output += parsed_secret
+        output.append(parsed_secret)
         parsed_secret_names.append(parsed_secret_name)
 
-    set_github_action_output("secrets-list", output, github_output_delimter)
+    set_github_action_output("secrets-list", "\n".join(output), github_output_delimter)
     set_github_action_output(
         "secret-names", ",".join(parsed_secret_names), github_output_delimter
     )

--- a/actions/gcp-gsm-parse-secrets/main.py
+++ b/actions/gcp-gsm-parse-secrets/main.py
@@ -68,7 +68,7 @@ def main(
         "secrets-list", "\n".join(output) + "\n", github_output_delimter
     )
     set_github_action_output(
-        "secret-names", ",".join(parsed_secret_names), github_output_delimter
+        "secret-names", ",".join(parsed_secret_names) + "\n", github_output_delimter
     )
 
 

--- a/actions/gcp-gsm-parse-secrets/main.py
+++ b/actions/gcp-gsm-parse-secrets/main.py
@@ -64,7 +64,9 @@ def main(
         output.append(parsed_secret)
         parsed_secret_names.append(parsed_secret_name)
 
-    set_github_action_output("secrets-list", "\n".join(output), github_output_delimter)
+    set_github_action_output(
+        "secrets-list", "\n".join(output) + "\n", github_output_delimter
+    )
     # set_github_action_output(
     #     "secret-names", ",".join(parsed_secret_names), github_output_delimter
     # )

--- a/actions/gcp-gsm-parse-secrets/main.py
+++ b/actions/gcp-gsm-parse-secrets/main.py
@@ -67,9 +67,9 @@ def main(
     set_github_action_output(
         "secrets-list", "\n".join(output) + "\n", github_output_delimter
     )
-    # set_github_action_output(
-    #     "secret-names", ",".join(parsed_secret_names), github_output_delimter
-    # )
+    set_github_action_output(
+        "secret-names", ",".join(parsed_secret_names), github_output_delimter
+    )
 
 
 if __name__ == "__main__":

--- a/actions/gcp-gsm-parse-secrets/main.py
+++ b/actions/gcp-gsm-parse-secrets/main.py
@@ -44,7 +44,7 @@ def parse_secret(secret, project_name, delim=DEFAULT_DELIMITER):
     out = f"{secret_name}:{project_name}/{components[0]}"
     if len(components) == 2 and len(components[1]) != 0:
         out += f"/{components[1]}"
-    return out
+    return out, secret_name
 
 
 def main(
@@ -56,10 +56,18 @@ def main(
     input_secrets = set(input_secrets.splitlines())
 
     output = ""
+    parsed_secret_names = []
     for secret in input_secrets:
-        output += parse_secret(secret, gcp_project, github_output_delimter) + "\n"
+        parsed_secret, parsed_secret_name = (
+            parse_secret(secret, gcp_project, github_output_delimter) + "\n"
+        )
+        output += parsed_secret
+        parsed_secret_names.append(parsed_secret_name)
 
     set_github_action_output("secrets-list", output, github_output_delimter)
+    set_github_action_output(
+        "secret-names", ",".join(parsed_secret_names), github_output_delimter
+    )
 
 
 if __name__ == "__main__":

--- a/actions/gcp-gsm-parse-secrets/main.py
+++ b/actions/gcp-gsm-parse-secrets/main.py
@@ -65,9 +65,9 @@ def main(
         parsed_secret_names.append(parsed_secret_name)
 
     set_github_action_output("secrets-list", "\n".join(output), github_output_delimter)
-    set_github_action_output(
-        "secret-names", ",".join(parsed_secret_names), github_output_delimter
-    )
+    # set_github_action_output(
+    #     "secret-names", ",".join(parsed_secret_names), github_output_delimter
+    # )
 
 
 if __name__ == "__main__":

--- a/actions/gcp-gsm-parse-secrets/tests.py
+++ b/actions/gcp-gsm-parse-secrets/tests.py
@@ -2,17 +2,36 @@ import unittest
 
 from main import parse_secret
 
+
 class TestParseSecret(unittest.TestCase):
     def test_parse_secret(self):
-        self.assertEqual(parse_secret("secret_name", "project_name"), "SECRET_NAME:project_name/secret_name")
-        self.assertEqual(parse_secret("secret_name/version", "project_name"), "SECRET_NAME:project_name/secret_name/version")
-        self.assertEqual(parse_secret("123-456", "project_name"), "123_456:project_name/123-456")
-        self.assertEqual(parse_secret("123___123___123", "project_name"), "123_123_123:project_name/123___123___123")
-        self.assertEqual(parse_secret("i-like_trains__why_this?", "project_name"), "I_LIKE_TRAINS_WHY_THIS:project_name/i-like_trains__why_this?")
+        self.assertEqual(
+            parse_secret("secret_name", "project_name")[0],
+            "SECRET_NAME:project_name/secret_name",
+        )
+        self.assertEqual(
+            parse_secret("secret_name/version", "project_name")[0],
+            "SECRET_NAME:project_name/secret_name/version",
+        )
+        self.assertEqual(
+            parse_secret("123-456", "project_name")[0], "123_456:project_name/123-456"
+        )
+        self.assertEqual(
+            parse_secret("123___123___123", "project_name")[0],
+            "123_123_123:project_name/123___123___123",
+        )
+        self.assertEqual(
+            parse_secret("i-like_trains__why_this?", "project_name")[0],
+            "I_LIKE_TRAINS_WHY_THIS:project_name/i-like_trains__why_this?",
+        )
 
     def test_parse_secret_special(self):
         # FIXME: this test is failing and i dont know why
-        self.assertEqual(parse_secret("123&&123()123__123*__*_123", "project_name"), "123_123_123_123:project_name/123&&123()123__123*__*_123")
+        self.assertEqual(
+            parse_secret("123&&123()123__123*__*_123", "project_name")[0],
+            "123_123_123_123:project_name/123&&123()123__123*__*_123",
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/docs/actions/gcp-gsm-load-secrets/README.md
+++ b/docs/actions/gcp-gsm-load-secrets/README.md
@@ -47,9 +47,9 @@ To load a secret from GSM figure out the following:
 
 <!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
 
-| OUTPUT  | TYPE   | DESCRIPTION                        |
-| ------- | ------ | ---------------------------------- |
-| secrets | string | Secrets loaded from Secret Manager |
+| OUTPUT       | TYPE   | DESCRIPTION                          |
+| ------------ | ------ | ------------------------------------ |
+| secret-names | string | Comma-separated list of secret names |
 
 <!-- AUTO-DOC-OUTPUT:END -->
 

--- a/docs/actions/gcp-gsm-load-secrets/README.md
+++ b/docs/actions/gcp-gsm-load-secrets/README.md
@@ -47,7 +47,9 @@ To load a secret from GSM figure out the following:
 
 <!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
 
-No outputs.
+| OUTPUT             | TYPE   | DESCRIPTION                  |
+| ------------------ | ------ | ---------------------------- |
+| secret-json-string | string | JSON string with all secrets |
 
 <!-- AUTO-DOC-OUTPUT:END -->
 

--- a/docs/actions/gcp-gsm-load-secrets/README.md
+++ b/docs/actions/gcp-gsm-load-secrets/README.md
@@ -47,9 +47,7 @@ To load a secret from GSM figure out the following:
 
 <!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
 
-| OUTPUT       | TYPE   | DESCRIPTION                          |
-| ------------ | ------ | ------------------------------------ |
-| secret-names | string | Comma-separated list of secret names |
+No outputs.
 
 <!-- AUTO-DOC-OUTPUT:END -->
 


### PR DESCRIPTION
![Unbenannt](https://github.com/user-attachments/assets/7c4643f2-5e81-4eeb-a754-00d01c6e7589)
As you can see by the commit history - this was a ride which ultimately led me back to the `toJSON` workaround, in which usability suffers quite a bit. There has to be a better solution to this than just chaining actions together and glueing them togehter, but for now this is functional. 

Here is an example workflow that works:
```yaml
name: test

on:
  workflow_dispatch:

permissions:
  contents: read
  id-token: write

jobs:
  test-secret-fetch:
    name: load secrets
    runs-on: ubuntu-latest

    steps:
      - name: Load secrets
        id: load-secrets
        uses: bakdata/ci-templates/actions/gcp-gsm-load-secrets@tiedemann/gsm-object-outputs-fix
        with:
          gke-project-name: <redacted>
          workload-identity-provider: <redacted>
          gke-service-account: <redacted>
          secrets-to-inject: |-
             CRABBY_PATTY_FORMULA/1
      - name: test exported
        run: |
          echo "${{ fromJSON(steps.load-secrets.outputs.secret-json-string).CRABBY_PATTY_FORMULA }}" | rev
```

As you can see this is less then ideal but it works.
Just as a though, having 2 vanilla actions (gcp auth + gsm get secrets) might be a whole lot easier than rolling our own stuff. Maybe we just take the learnings and have sth simple. 

