### PR TITLE
Allow configuring changelog file for bump-version-release workflow

### DIFF
--- a/.github/workflows/bump-version-release.yaml
+++ b/.github/workflows/bump-version-release.yaml
@@ -13,6 +13,11 @@ on:
         required: false
         default: true
         type: boolean
+      changelog-file:
+        description: Path to the changelog file in the GitHub repository
+        required: false
+        default: "CHANGELOG.md"
+        type: string
       changelog-config:
         description: "Changelog config path."
         required: false
@@ -74,7 +79,7 @@ jobs:
         with:
           github-token: ${{ secrets.github-token }}
           tag: ${{ steps.bump-version.outputs.release-version }}
-          changelog-file: CHANGELOG.md
+          changelog-file: ${{ inputs.changelog-file }}
 
       - name: Commit and push changes including .bumpversion.cfg file
         uses: bakdata/ci-templates/actions/commit-and-push@v1.6.0

--- a/docs/workflows/bump-version-release/README.md
+++ b/docs/workflows/bump-version-release/README.md
@@ -61,12 +61,13 @@ jobs:
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-| INPUT             | TYPE    | REQUIRED | DEFAULT | DESCRIPTION                                                     |
-| ----------------- | ------- | -------- | ------- | --------------------------------------------------------------- |
-| changelog         | boolean | false    | `true`  | Create changelog for release.                                   |
-| changelog-config  | string  | false    |         | Changelog config path.                                          |
-| release-type      | string  | true     |         | Scope of the release (major, minor or patch).                   |
-| working-directory | string  | false    | `"."`   | Working directory containing `.bumpversion.cfg`. (Default is .) |
+| INPUT             | TYPE    | REQUIRED | DEFAULT          | DESCRIPTION                                                     |
+| ----------------- | ------- | -------- | ---------------- | --------------------------------------------------------------- |
+| changelog         | boolean | false    | `true`           | Create changelog for release.                                   |
+| changelog-config  | string  | false    |                  | Changelog config path.                                          |
+| changelog-file    | string  | false    | `"CHANGELOG.md"` | Path to the changelog file in the GitHub repository             |
+| release-type      | string  | true     |                  | Scope of the release (major, minor or patch).                   |
+| working-directory | string  | false    | `"."`            | Working directory containing `.bumpversion.cfg`. (Default is .) |
 
 <!-- AUTO-DOC-INPUT:END -->
 


### PR DESCRIPTION
same as for python-poetry-release workflow
