### PR TITLE
hotfix: remove everything git-cliff related (brutally)

### DIFF
--- a/actions/changelog-generate/action.yaml
+++ b/actions/changelog-generate/action.yaml
@@ -69,5 +69,5 @@ runs:
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
     - name: remove tmp config file
-      run: rm tmp_cliff.toml && rm -rf git-cliff/
+      run: rm tmp_cliff.toml && rm -rf git-cliff*
       shell: bash


### PR DESCRIPTION
fixes the addition of random git-cliff binaries in releases and git repos

this is a bandaid fix - i will look into a cleaner solution, i.e. adapting the git-cliff action to not download the artifacts into the main directory.
