### PR TITLE
Create Gradle changelogs using git-cliff

### DIFF
--- a/.github/generate-doc.py
+++ b/.github/generate-doc.py
@@ -154,6 +154,7 @@ def copy_file(source_path, destination_path):
 
 
 def run():
+    null_out = "NUL" if os.name == 'nt' else "/dev/null"
     auto_doc_cmd = os.environ.get("DOC_CMD")
     if auto_doc_cmd is None or auto_doc_cmd == "":
         auto_doc_cmd = "auto-doc"
@@ -191,7 +192,7 @@ def run():
             for line in template[: -1]:
                 file_action_template.write(line + '\n')
         os.system(
-            f"{auto_doc_cmd} -f {action_file} --colMaxWidth 10000 --colMaxWords 2000 -o {tmp_docu_output_action} > /dev/null")
+            f"{auto_doc_cmd} -f {action_file} --colMaxWidth 10000 --colMaxWords 2000 -o {tmp_docu_output_action} > {null_out}")
         replace_string_in_markdown(tmp_docu_output_action, "# ", "## ")
 
         output_file_action = os.path.join(
@@ -224,7 +225,7 @@ def run():
                     file_workflow_template.write(line + '\n')
 
             os.system(
-                f"{auto_doc_cmd} -f {workflow_path} --colMaxWidth 10000 --colMaxWords 2000 -o {tmp_docu_output_workflow} -r > /dev/null")
+                f"{auto_doc_cmd} -f {workflow_path} --colMaxWidth 10000 --colMaxWords 2000 -o {tmp_docu_output_workflow} -r > {null_out}")
             replace_string_in_markdown(
                 tmp_docu_output_workflow, "# ", "## ")
 

--- a/.github/workflows/bump-version-release.yaml
+++ b/.github/workflows/bump-version-release.yaml
@@ -78,7 +78,7 @@ jobs:
         if: ${{ inputs.changelog }}
         with:
           github-token: ${{ secrets.github-token }}
-          additional-cliff-args: --unreleased --tag ${{ inputs.tag }}
+          additional-cliff-args: --unreleased --tag ${{ steps.bump-version.outputs.release-version }}
 
       - name: Create changelog
         uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
@@ -86,7 +86,7 @@ jobs:
         with:
           github-token: ${{ secrets.github-token }}
           changelog-file: ${{ inputs.changelog-file }}
-          additional-cliff-args: --tag ${{ inputs.tag }}
+          additional-cliff-args: --tag ${{ steps.bump-version.outputs.release-version }}
 
       - name: Commit and push changes including .bumpversion.cfg file
         uses: bakdata/ci-templates/actions/commit-and-push@v1.6.0

--- a/.github/workflows/bump-version-release.yaml
+++ b/.github/workflows/bump-version-release.yaml
@@ -72,14 +72,21 @@ jobs:
           release-type: ${{ inputs.release-type }}
           working-directory: ${{ inputs.working-directory }}
 
-      - name: Create changelog
+      - name: Create single changelog
         id: build-changelog
-        uses: bakdata/ci-templates/actions/changelog-generate@1.69.1
+        uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
         if: ${{ inputs.changelog }}
         with:
           github-token: ${{ secrets.github-token }}
-          tag: ${{ steps.bump-version.outputs.release-version }}
+          additional-cliff-args: --unreleased --tag ${{ inputs.tag }}
+
+      - name: Create changelog
+        uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
+        if: ${{ inputs.changelog }}
+        with:
+          github-token: ${{ secrets.github-token }}
           changelog-file: ${{ inputs.changelog-file }}
+          additional-cliff-args: --tag ${{ inputs.tag }}
 
       - name: Commit and push changes including .bumpversion.cfg file
         uses: bakdata/ci-templates/actions/commit-and-push@v1.6.0
@@ -98,4 +105,4 @@ jobs:
           github-email: ${{ secrets.github-email }}
           github-token: ${{ secrets.github-token }}
           release-title: "${{ steps.bump-version.outputs.release-version }}"
-          release-body: "${{ steps.build-changelog.outputs.single-changelog }}"
+          release-body: "${{ steps.build-changelog.outputs.changelog }}"

--- a/.github/workflows/bump-version-release.yaml
+++ b/.github/workflows/bump-version-release.yaml
@@ -74,14 +74,14 @@ jobs:
 
       - name: Create single changelog
         id: build-changelog
-        uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
+        uses: bakdata/ci-templates/actions/changelog-generate@1.70.0
         if: ${{ inputs.changelog }}
         with:
           github-token: ${{ secrets.github-token }}
           additional-cliff-args: --unreleased --tag ${{ steps.bump-version.outputs.release-version }}
 
       - name: Create changelog
-        uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
+        uses: bakdata/ci-templates/actions/changelog-generate@1.70.0
         if: ${{ inputs.changelog }}
         with:
           github-token: ${{ secrets.github-token }}

--- a/.github/workflows/java-gradle-docker.yaml
+++ b/.github/workflows/java-gradle-docker.yaml
@@ -167,7 +167,7 @@ jobs:
 
     steps:
       - name: Release on Github
-        uses: bakdata/ci-templates/actions/java-gradle-release-github@feature/gradle-release-git-cliff
+        uses: bakdata/ci-templates/actions/java-gradle-release-github@1.70.0
         with:
           github-token: ${{ secrets.github-token }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/java-gradle-docker.yaml
+++ b/.github/workflows/java-gradle-docker.yaml
@@ -167,7 +167,7 @@ jobs:
 
     steps:
       - name: Release on Github
-        uses: bakdata/ci-templates/actions/java-gradle-release-github@1.63.0
+        uses: bakdata/ci-templates/actions/java-gradle-release-github@feature/gradle-release-git-cliff
         with:
           github-token: ${{ secrets.github-token }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/java-gradle-library.yaml
+++ b/.github/workflows/java-gradle-library.yaml
@@ -121,7 +121,7 @@ jobs:
 
     steps:
       - name: Release on Github
-        uses: bakdata/ci-templates/actions/java-gradle-release-github@feature/gradle-release-git-cliff
+        uses: bakdata/ci-templates/actions/java-gradle-release-github@1.70.0
         with:
           github-token: ${{ secrets.github-token }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/java-gradle-library.yaml
+++ b/.github/workflows/java-gradle-library.yaml
@@ -121,7 +121,7 @@ jobs:
 
     steps:
       - name: Release on Github
-        uses: bakdata/ci-templates/actions/java-gradle-release-github@1.63.0
+        uses: bakdata/ci-templates/actions/java-gradle-release-github@feature/gradle-release-git-cliff
         with:
           github-token: ${{ secrets.github-token }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/java-gradle-plugin.yaml
+++ b/.github/workflows/java-gradle-plugin.yaml
@@ -149,7 +149,7 @@ jobs:
 
     steps:
       - name: Release on Github
-        uses: bakdata/ci-templates/actions/java-gradle-release-github@feature/gradle-release-git-cliff
+        uses: bakdata/ci-templates/actions/java-gradle-release-github@1.70.0
         with:
           github-token: ${{ secrets.github-token }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/java-gradle-plugin.yaml
+++ b/.github/workflows/java-gradle-plugin.yaml
@@ -149,7 +149,7 @@ jobs:
 
     steps:
       - name: Release on Github
-        uses: bakdata/ci-templates/actions/java-gradle-release-github@1.63.0
+        uses: bakdata/ci-templates/actions/java-gradle-release-github@feature/gradle-release-git-cliff
         with:
           github-token: ${{ secrets.github-token }}
           java-distribution: ${{ inputs.java-distribution }}

--- a/.github/workflows/java-gradle-release.yaml
+++ b/.github/workflows/java-gradle-release.yaml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Release on Github
         id: release
-        uses: bakdata/ci-templates/actions/java-gradle-release@1.63.0
+        uses: bakdata/ci-templates/actions/java-gradle-release@feature/gradle-release-git-cliff
         with:
           release-type: ${{ inputs.release-type }}
           github-email: ${{ secrets.github-email }}

--- a/.github/workflows/java-gradle-release.yaml
+++ b/.github/workflows/java-gradle-release.yaml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Release on Github
         id: release
-        uses: bakdata/ci-templates/actions/java-gradle-release@feature/gradle-release-git-cliff
+        uses: bakdata/ci-templates/actions/java-gradle-release@1.70.0
         with:
           release-type: ${{ inputs.release-type }}
           github-email: ${{ secrets.github-email }}

--- a/.github/workflows/python-poetry-release.yaml
+++ b/.github/workflows/python-poetry-release.yaml
@@ -91,14 +91,14 @@ jobs:
 
       - name: Create single changelog
         id: build-changelog
-        uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
+        uses: bakdata/ci-templates/actions/changelog-generate@1.70.0
         if: ${{ inputs.changelog }}
         with:
           github-token: ${{ secrets.github-token }}
           additional-cliff-args: --unreleased --tag ${{ steps.bump-version.outputs.release-version }}
 
       - name: Create changelog
-        uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
+        uses: bakdata/ci-templates/actions/changelog-generate@1.70.0
         if: ${{ inputs.changelog }}
         with:
           github-token: ${{ secrets.github-token }}

--- a/.github/workflows/python-poetry-release.yaml
+++ b/.github/workflows/python-poetry-release.yaml
@@ -95,7 +95,7 @@ jobs:
         if: ${{ inputs.changelog }}
         with:
           github-token: ${{ secrets.github-token }}
-          additional-cliff-args: --unreleased --tag ${{ inputs.tag }}
+          additional-cliff-args: --unreleased --tag ${{ steps.bump-version.outputs.release-version }}
 
       - name: Create changelog
         uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
@@ -103,7 +103,7 @@ jobs:
         with:
           github-token: ${{ secrets.github-token }}
           changelog-file: ${{ inputs.changelog-file }}
-          additional-cliff-args: --tag ${{ inputs.tag }}
+          additional-cliff-args: --tag ${{ steps.bump-version.outputs.release-version }}
 
       - name: Commit and push pyproject.toml file
         uses: bakdata/ci-templates/actions/commit-and-push@1.25.2

--- a/.github/workflows/python-poetry-release.yaml
+++ b/.github/workflows/python-poetry-release.yaml
@@ -89,14 +89,21 @@ jobs:
           poetry-version: ${{ inputs.poetry-version }}
           working-directory: ${{ inputs.working-directory }}
 
-      - name: Create changelog
+      - name: Create single changelog
         id: build-changelog
-        uses: bakdata/ci-templates/actions/changelog-generate@1.69.1
+        uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
         if: ${{ inputs.changelog }}
         with:
           github-token: ${{ secrets.github-token }}
-          tag: ${{ steps.bump-version.outputs.release-version }}
+          additional-cliff-args: --unreleased --tag ${{ inputs.tag }}
+
+      - name: Create changelog
+        uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
+        if: ${{ inputs.changelog }}
+        with:
+          github-token: ${{ secrets.github-token }}
           changelog-file: ${{ inputs.changelog-file }}
+          additional-cliff-args: --tag ${{ inputs.tag }}
 
       - name: Commit and push pyproject.toml file
         uses: bakdata/ci-templates/actions/commit-and-push@1.25.2
@@ -113,7 +120,7 @@ jobs:
         with:
           tag: "${{ steps.bump-version.outputs.release-version }}"
           release-title: "${{ steps.bump-version.outputs.release-version }}"
-          release-body: "${{ steps.build-changelog.outputs.single-changelog }}"
+          release-body: "${{ steps.build-changelog.outputs.changelog }}"
           github-username: ${{ secrets.github-username }}
           github-email: ${{ secrets.github-email }}
           github-token: ${{ secrets.github-token }}

--- a/.github/workflows/python-uv-release.yaml
+++ b/.github/workflows/python-uv-release.yaml
@@ -98,14 +98,21 @@ jobs:
       - name: Apply version bump to uv lock
         run: uv lock --no-refresh
 
-      - name: Create changelog
+      - name: Create single changelog
         id: build-changelog
-        uses: bakdata/ci-templates/actions/changelog-generate@1.69.1
+        uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
         if: ${{ inputs.changelog }}
         with:
           github-token: ${{ secrets.github-token }}
-          tag: ${{ steps.bump-version-release.outputs.release-version }}
+          additional-cliff-args: --unreleased --tag ${{ inputs.tag }}
+
+      - name: Create changelog
+        uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
+        if: ${{ inputs.changelog }}
+        with:
+          github-token: ${{ secrets.github-token }}
           changelog-file: ${{ inputs.changelog-file }}
+          additional-cliff-args: --tag ${{ inputs.tag }}
 
       - name: Commit and push changes including .bumpversion.cfg file
         uses: bakdata/ci-templates/actions/commit-and-push@1.64.0
@@ -125,4 +132,4 @@ jobs:
           github-email: ${{ secrets.github-email }}
           github-token: ${{ secrets.github-token }}
           release-title: "${{ steps.bump-version-release.outputs.release-version }}"
-          release-body: "${{ steps.build-changelog.outputs.single-changelog }}"
+          release-body: "${{ steps.build-changelog.outputs.changelog }}"

--- a/.github/workflows/python-uv-release.yaml
+++ b/.github/workflows/python-uv-release.yaml
@@ -104,7 +104,7 @@ jobs:
         if: ${{ inputs.changelog }}
         with:
           github-token: ${{ secrets.github-token }}
-          additional-cliff-args: --unreleased --tag ${{ steps.bump-version.outputs.release-version }}
+          additional-cliff-args: --unreleased --tag ${{ steps.bump-version-release.outputs.release-version }}
 
       - name: Create changelog
         uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
@@ -112,7 +112,7 @@ jobs:
         with:
           github-token: ${{ secrets.github-token }}
           changelog-file: ${{ inputs.changelog-file }}
-          additional-cliff-args: --tag ${{ steps.bump-version.outputs.release-version }}
+          additional-cliff-args: --tag ${{ steps.bump-version-release.outputs.release-version }}
 
       - name: Commit and push changes including .bumpversion.cfg file
         uses: bakdata/ci-templates/actions/commit-and-push@1.64.0

--- a/.github/workflows/python-uv-release.yaml
+++ b/.github/workflows/python-uv-release.yaml
@@ -104,7 +104,7 @@ jobs:
         if: ${{ inputs.changelog }}
         with:
           github-token: ${{ secrets.github-token }}
-          additional-cliff-args: --unreleased --tag ${{ inputs.tag }}
+          additional-cliff-args: --unreleased --tag ${{ steps.bump-version.outputs.release-version }}
 
       - name: Create changelog
         uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
@@ -112,7 +112,7 @@ jobs:
         with:
           github-token: ${{ secrets.github-token }}
           changelog-file: ${{ inputs.changelog-file }}
-          additional-cliff-args: --tag ${{ inputs.tag }}
+          additional-cliff-args: --tag ${{ steps.bump-version.outputs.release-version }}
 
       - name: Commit and push changes including .bumpversion.cfg file
         uses: bakdata/ci-templates/actions/commit-and-push@1.64.0

--- a/.github/workflows/python-uv-release.yaml
+++ b/.github/workflows/python-uv-release.yaml
@@ -100,14 +100,14 @@ jobs:
 
       - name: Create single changelog
         id: build-changelog
-        uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
+        uses: bakdata/ci-templates/actions/changelog-generate@1.70.0
         if: ${{ inputs.changelog }}
         with:
           github-token: ${{ secrets.github-token }}
           additional-cliff-args: --unreleased --tag ${{ steps.bump-version-release.outputs.release-version }}
 
       - name: Create changelog
-        uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
+        uses: bakdata/ci-templates/actions/changelog-generate@1.70.0
         if: ${{ inputs.changelog }}
         with:
           github-token: ${{ secrets.github-token }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
       - id: auto-doc
         language: python
         name: Generate doc
-        entry: python3 .github/generate-doc.py
+        entry: python .github/generate-doc.py
         always_run: true
         require_serial: true
         verbose: true

--- a/actions/changelog-generate/action.yaml
+++ b/actions/changelog-generate/action.yaml
@@ -69,6 +69,9 @@ runs:
         # BUT, it works and the file will be written over in the next step anyway
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
+    - name: Print changelog
+      run: echo ${{ steps.git-cliff-latest.outputs.content }}
+      shell: bash
     - name: Generate a changelog
       uses: orhun/git-cliff-action@v4.5.1
       id: git-cliff
@@ -78,6 +81,9 @@ runs:
       env:
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
+    - name: Print changelog
+      run: echo ${{ steps.git-cliff.outputs.content }}
+      shell: bash
     - name: remove tmp config file
       run: rm tmp_cliff.toml
       shell: bash

--- a/actions/changelog-generate/action.yaml
+++ b/actions/changelog-generate/action.yaml
@@ -69,6 +69,9 @@ runs:
         # BUT, it works and the file will be written over in the next step anyway
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
+    - name: Print changelog
+      run: cat ${{ inputs.changelog-file }}
+      shell: bash
     - name: Generate a changelog
       uses: orhun/git-cliff-action@v4.5.1
       id: git-cliff
@@ -78,6 +81,8 @@ runs:
       env:
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
+    - name: Print changelog
+      run: cat ${{ inputs.changelog-file }}
     - name: remove tmp config file
       run: rm tmp_cliff.toml
       shell: bash

--- a/actions/changelog-generate/action.yaml
+++ b/actions/changelog-generate/action.yaml
@@ -62,11 +62,8 @@ runs:
       id: git-cliff-latest
       with:
         config: tmp_cliff.toml
-        args: "--tag ${{ inputs.tag }} ${{ inputs.verbose == 'true' && '--verbose' || '' }} ${{ inputs.additional-cliff-args }}"
+        args: "--unreleased --tag ${{ inputs.tag }} ${{ inputs.verbose == 'true' && '--verbose' || '' }} ${{ inputs.additional-cliff-args }}"
       env:
-        # I am not a fan of this, cuz this does not reflect what this step is supposed to do
-        # i.e. just dumping the latest changelog into GHA context
-        # BUT, it works and the file will be written over in the next step anyway
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
     - name: Print changelog
@@ -77,7 +74,7 @@ runs:
       id: git-cliff
       with:
         config: tmp_cliff.toml
-        args: "--tag ${{ inputs.tag }} --output ${{ inputs.changelog-file }} ${{ inputs.verbose == 'true' && '--verbose' || '' }} ${{ inputs.additional-cliff-args }}"
+        args: "--unreleased --tag ${{ inputs.tag }} ${{ (inputs.changelog-file != '' && format('--output {0}', inputs.changelog-file)) || '' }} ${{ inputs.verbose == 'true' && '--verbose' || '' }} ${{ inputs.additional-cliff-args }}"
       env:
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/actions/changelog-generate/action.yaml
+++ b/actions/changelog-generate/action.yaml
@@ -66,9 +66,6 @@ runs:
       env:
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
-    - name: Print changelog
-      run: echo "${{ steps.git-cliff-latest.outputs.content }}"
-      shell: bash
     - name: Generate a changelog
       uses: orhun/git-cliff-action@v4.5.1
       id: git-cliff
@@ -78,9 +75,6 @@ runs:
       env:
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
-    - name: Print changelog
-      run: echo "${{ steps.git-cliff.outputs.content }}"
-      shell: bash
     - name: remove tmp config file
       run: rm tmp_cliff.toml
       shell: bash

--- a/actions/changelog-generate/action.yaml
+++ b/actions/changelog-generate/action.yaml
@@ -5,9 +5,6 @@ inputs:
   github-token:
     description: "The GitHub token for committing the changes."
     required: true
-  tag:
-    description: Version after bump
-    required: true
   # optional inputs
   changelog-file:
     description: Path to the changelog file in the GitHub repository
@@ -31,12 +28,9 @@ inputs:
     default: ""
 
 outputs:
-  merged-changelog:
-    description: "All changelogs combined."
+  changelog:
+    description: "Changelog output."
     value: ${{ steps.git-cliff.outputs.content }}
-  single-changelog:
-    description: "Only the latest changelog."
-    value: ${{ steps.git-cliff-latest.outputs.content }}
 
 runs:
   using: "composite"
@@ -57,21 +51,12 @@ runs:
           cp $DEFAULT_PATH tmp_cliff.toml
         fi
       shell: bash
-    - name: Generate latest only changelog
-      uses: orhun/git-cliff-action@v4.5.1
-      id: git-cliff-latest
-      with:
-        config: tmp_cliff.toml
-        args: "--unreleased --tag ${{ inputs.tag }} ${{ inputs.verbose == 'true' && '--verbose' || '' }} ${{ inputs.additional-cliff-args }}"
-      env:
-        GITHUB_REPO: ${{ github.repository }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
     - name: Generate a changelog
       uses: orhun/git-cliff-action@v4.5.1
       id: git-cliff
       with:
         config: tmp_cliff.toml
-        args: "--tag ${{ inputs.tag }} ${{ (inputs.changelog-file != '' && format('--output {0}', inputs.changelog-file)) || '' }} ${{ inputs.verbose == 'true' && '--verbose' || '' }} ${{ inputs.additional-cliff-args }}"
+        args: "${{ (inputs.changelog-file != '' && format('--output {0}', inputs.changelog-file)) || '' }} ${{ inputs.verbose == 'true' && '--verbose' || '' }} ${{ inputs.additional-cliff-args }}"
       env:
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/actions/changelog-generate/action.yaml
+++ b/actions/changelog-generate/action.yaml
@@ -83,6 +83,7 @@ runs:
         GITHUB_TOKEN: ${{ inputs.github-token }}
     - name: Print changelog
       run: cat ${{ inputs.changelog-file }}
+      shell: bash
     - name: remove tmp config file
       run: rm tmp_cliff.toml
       shell: bash

--- a/actions/changelog-generate/action.yaml
+++ b/actions/changelog-generate/action.yaml
@@ -9,7 +9,7 @@ inputs:
   changelog-file:
     description: Path to the changelog file in the GitHub repository
     required: false
-    default: "CHANGELOG.md"
+    default: ""
   checkout:
     description: "Whether to checkout the repository or not."
     required: false
@@ -64,5 +64,5 @@ runs:
       run: rm tmp_cliff.toml
       shell: bash
     - name: remove git-cliff stuff
-      run: rm -r git-cliff/
+      run: rm -r git-cliff/ # git-cliff action does not use temp dir properly
       shell: bash

--- a/actions/changelog-generate/action.yaml
+++ b/actions/changelog-generate/action.yaml
@@ -71,7 +71,7 @@ runs:
       id: git-cliff
       with:
         config: tmp_cliff.toml
-        args: "--unreleased --tag ${{ inputs.tag }} ${{ (inputs.changelog-file != '' && format('--output {0}', inputs.changelog-file)) || '' }} ${{ inputs.verbose == 'true' && '--verbose' || '' }} ${{ inputs.additional-cliff-args }}"
+        args: "--tag ${{ inputs.tag }} ${{ (inputs.changelog-file != '' && format('--output {0}', inputs.changelog-file)) || '' }} ${{ inputs.verbose == 'true' && '--verbose' || '' }} ${{ inputs.additional-cliff-args }}"
       env:
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/actions/changelog-generate/action.yaml
+++ b/actions/changelog-generate/action.yaml
@@ -84,3 +84,6 @@ runs:
     - name: remove tmp config file
       run: rm tmp_cliff.toml
       shell: bash
+    - name: remove git-cliff stuff
+      run: rm -r git-cliff/
+      shell: bash

--- a/actions/changelog-generate/action.yaml
+++ b/actions/changelog-generate/action.yaml
@@ -62,16 +62,13 @@ runs:
       id: git-cliff-latest
       with:
         config: tmp_cliff.toml
-        args: "--unreleased --tag ${{ inputs.tag }} ${{ inputs.verbose == 'true' && '--verbose' || '' }} ${{ inputs.additional-cliff-args }}"
+        args: "--tag ${{ inputs.tag }} ${{ inputs.verbose == 'true' && '--verbose' || '' }} ${{ inputs.additional-cliff-args }}"
       env:
         # I am not a fan of this, cuz this does not reflect what this step is supposed to do
         # i.e. just dumping the latest changelog into GHA context
         # BUT, it works and the file will be written over in the next step anyway
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
-    - name: Print changelog
-      run: cat ${{ inputs.changelog-file }}
-      shell: bash
     - name: Generate a changelog
       uses: orhun/git-cliff-action@v4.5.1
       id: git-cliff
@@ -81,9 +78,6 @@ runs:
       env:
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
-    - name: Print changelog
-      run: cat ${{ inputs.changelog-file }}
-      shell: bash
     - name: remove tmp config file
       run: rm tmp_cliff.toml
       shell: bash

--- a/actions/changelog-generate/action.yaml
+++ b/actions/changelog-generate/action.yaml
@@ -70,7 +70,7 @@ runs:
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
     - name: Print changelog
-      run: echo ${{ steps.git-cliff-latest.outputs.content }}
+      run: echo "${{ steps.git-cliff-latest.outputs.content }}"
       shell: bash
     - name: Generate a changelog
       uses: orhun/git-cliff-action@v4.5.1
@@ -82,7 +82,7 @@ runs:
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
     - name: Print changelog
-      run: echo ${{ steps.git-cliff.outputs.content }}
+      run: echo "${{ steps.git-cliff.outputs.content }}"
       shell: bash
     - name: remove tmp config file
       run: rm tmp_cliff.toml

--- a/actions/changelog-generate/action.yaml
+++ b/actions/changelog-generate/action.yaml
@@ -67,7 +67,6 @@ runs:
         # I am not a fan of this, cuz this does not reflect what this step is supposed to do
         # i.e. just dumping the latest changelog into GHA context
         # BUT, it works and the file will be written over in the next step anyway
-        OUTPUT: ${{ inputs.changelog-file }}
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
     - name: Generate a changelog
@@ -75,9 +74,8 @@ runs:
       id: git-cliff
       with:
         config: tmp_cliff.toml
-        args: "--tag ${{ inputs.tag }} ${{ inputs.verbose == 'true' && '--verbose' || '' }} ${{ inputs.additional-cliff-args }}"
+        args: "--tag ${{ inputs.tag }} --output ${{ inputs.changelog-file }} ${{ inputs.verbose == 'true' && '--verbose' || '' }} ${{ inputs.additional-cliff-args }}"
       env:
-        OUTPUT: ${{ inputs.changelog-file }}
         GITHUB_REPO: ${{ github.repository }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
     - name: remove tmp config file

--- a/actions/changelog-generate/default-cliff.toml
+++ b/actions/changelog-generate/default-cliff.toml
@@ -55,7 +55,9 @@ conventional_commits = true
 filter_unconventional = false
 split_commits = false
 commit_preprocessors = []
-commit_parsers = []
+commit_parsers = [
+  { field = "author.email", pattern = ".*bot@.*", skip = true }
+]
 protect_breaking_commits = false
 filter_commits = false
 topo_order = false

--- a/actions/java-gradle-release-github/action.yaml
+++ b/actions/java-gradle-release-github/action.yaml
@@ -24,7 +24,7 @@ runs:
       uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
       with:
         github-token: ${{ inputs.github-token }}
-        additional-cliff-args: --current
+        additional-cliff-args: --tag ${{ github.ref_name }} --strip all
 
     - name: Create Github release
       uses: softprops/action-gh-release@v2.0.4

--- a/actions/java-gradle-release-github/action.yaml
+++ b/actions/java-gradle-release-github/action.yaml
@@ -28,5 +28,5 @@ runs:
     - name: Create Github release
       uses: softprops/action-gh-release@v2.0.4
       with:
-        body: ${{ steps.changelog.outputs.single-changelog }}
+        body_path: CHANGELOG.md
         files: "**/build/libs/*.jar"

--- a/actions/java-gradle-release-github/action.yaml
+++ b/actions/java-gradle-release-github/action.yaml
@@ -29,5 +29,5 @@ runs:
     - name: Create Github release
       uses: softprops/action-gh-release@v2.0.4
       with:
-        body_path: ${{ steps.changelog.outputs.changelog }}
+        body: ${{ steps.changelog.outputs.changelog }}
         files: "**/build/libs/*.jar"

--- a/actions/java-gradle-release-github/action.yaml
+++ b/actions/java-gradle-release-github/action.yaml
@@ -28,5 +28,5 @@ runs:
     - name: Create Github release
       uses: softprops/action-gh-release@v2.0.4
       with:
-        body_path: CHANGELOG.md
+        body_path: ${{ steps.changelog.outputs.changelog }}
         files: "**/build/libs/*.jar"

--- a/actions/java-gradle-release-github/action.yaml
+++ b/actions/java-gradle-release-github/action.yaml
@@ -5,34 +5,6 @@ inputs:
   github-token:
     description: "GitHub token for requesting changes from API."
     required: true
-  java-distribution:
-    description: "Java distribution to be installed. (Default is microsoft)"
-    required: false
-    default: "microsoft"
-  java-version:
-    description: "Java version to be installed. (Default is 11)"
-    required: false
-    default: "11"
-  gradle-version:
-    description: "Gradle version to be installed. (Default is wrapper)"
-    required: false
-    default: "wrapper"
-  gradle-cache:
-    description: "Whether Gradle caching is enabled or not. (Default is true)"
-    required: false
-    default: true
-  gradle-cache-read-only:
-    description: "Whether Gradle caching should be read-only. By default this value is 'false' for workflows on the GitHub default branch and 'true' for workflows on other branches."
-    required: false
-    default: ${{ github.event.repository != null && github.ref_name != github.event.repository.default_branch }}
-  gradle-refresh-dependencies:
-    description: "Whether Gradle should refresh dependencies. (Default is false)"
-    required: false
-    default: "false"
-  working-directory:
-    description: "Working directory of your Gradle artifacts. (Default is .)"
-    required: false
-    default: "."
 runs:
   using: "composite"
   steps:
@@ -47,26 +19,14 @@ runs:
         name: build-artifact
         path: build
 
-    - name: Set up Gradle with version ${{ inputs.gradle-version }}
-      uses: bakdata/ci-templates/actions/java-gradle-setup@1.63.0
-      with:
-        java-distribution: ${{ inputs.java-distribution }}
-        java-version: ${{ inputs.java-version }}
-        gradle-version: ${{ inputs.gradle-version }}
-        gradle-cache: ${{ inputs.gradle-cache }}
-        gradle-cache-read-only: ${{ inputs.gradle-cache-read-only }}
-        gradle-dependency-graph: disabled
-
     - name: Generate changelog
-      run: ./gradlew -Pchangelog.githubRepository=${{ github.event.repository.name }} -Pchangelog.futureVersionTag=${{ github.ref_name }} -Pchangelog.sinceTag=${{ github.ref_name }} --stacktrace --info generateChangelog ${{ inputs.gradle-refresh-dependencies == 'true' && '--refresh-dependencies' || '' }}
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-      env:
-        GITHUB_USER: ${{ github.repository_owner }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+      uses: bakdata/ci-templates/actions/changelog-generate@1.69.2
+      with:
+        github-token: ${{ inputs.github-token }}
+        tag: ${{ github.ref_name }}
 
     - name: Create Github release
       uses: softprops/action-gh-release@v2.0.4
       with:
-        body_path: CHANGELOG.md
+        body: ${{ steps.changelog.outputs.single-changelog }}
         files: "**/build/libs/*.jar"

--- a/actions/java-gradle-release-github/action.yaml
+++ b/actions/java-gradle-release-github/action.yaml
@@ -21,7 +21,7 @@ runs:
 
     - name: Generate changelog
       id: changelog
-      uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
+      uses: bakdata/ci-templates/actions/changelog-generate@1.70.0
       with:
         github-token: ${{ inputs.github-token }}
         additional-cliff-args: --current --strip all # passing --tag ${{ github.ref_name }} generates a full changelog

--- a/actions/java-gradle-release-github/action.yaml
+++ b/actions/java-gradle-release-github/action.yaml
@@ -24,7 +24,7 @@ runs:
       uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
       with:
         github-token: ${{ inputs.github-token }}
-        additional-cliff-args: --current --strip all
+        additional-cliff-args: --current --strip all # passing --tag ${{ github.ref_name }} generates a full changelog
 
     - name: Create Github release
       uses: softprops/action-gh-release@v2.0.4

--- a/actions/java-gradle-release-github/action.yaml
+++ b/actions/java-gradle-release-github/action.yaml
@@ -23,7 +23,7 @@ runs:
       uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
       with:
         github-token: ${{ inputs.github-token }}
-        tag: ${{ github.ref_name }}
+        additional-cliff-args: --current
 
     - name: Create Github release
       uses: softprops/action-gh-release@v2.0.4

--- a/actions/java-gradle-release-github/action.yaml
+++ b/actions/java-gradle-release-github/action.yaml
@@ -20,7 +20,7 @@ runs:
         path: build
 
     - name: Generate changelog
-      uses: bakdata/ci-templates/actions/changelog-generate@1.69.2
+      uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
       with:
         github-token: ${{ inputs.github-token }}
         tag: ${{ github.ref_name }}

--- a/actions/java-gradle-release-github/action.yaml
+++ b/actions/java-gradle-release-github/action.yaml
@@ -24,7 +24,7 @@ runs:
       uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
       with:
         github-token: ${{ inputs.github-token }}
-        additional-cliff-args: --tag ${{ github.ref_name }} --strip all
+        additional-cliff-args: --current --strip all
 
     - name: Create Github release
       uses: softprops/action-gh-release@v2.0.4

--- a/actions/java-gradle-release-github/action.yaml
+++ b/actions/java-gradle-release-github/action.yaml
@@ -20,6 +20,7 @@ runs:
         path: build
 
     - name: Generate changelog
+      id: changelog
       uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
       with:
         github-token: ${{ inputs.github-token }}

--- a/actions/java-gradle-release/action.yaml
+++ b/actions/java-gradle-release/action.yaml
@@ -98,19 +98,21 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
-    - name: Create release
-      run: ./gradlew release -x test -Prelease.useAutomaticVersion=true -Prelease.releaseVersion=${{ steps.evaluate-version.outputs.release-version }} -Prelease.disablePushToRemote=true -Prelease.requireBranch=${{ github.event.repository.default_branch }} ${{ inputs.gradle-refresh-dependencies == 'true' && '--refresh-dependencies' || '' }}
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-
     - name: Create changelog
       uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
       with:
         github-token: ${{ inputs.github-token }}
         tag: ${{ steps.evaluate-version.outputs.release-version }}
+        changelog-file: ${{ runner.temp }}/CHANGELOG.md
+
+    - name: Create release
+      run: ./gradlew release -x test -Prelease.useAutomaticVersion=true -Prelease.releaseVersion=${{ steps.evaluate-version.outputs.release-version }} -Prelease.disablePushToRemote=true -Prelease.requireBranch=${{ github.event.repository.default_branch }} ${{ inputs.gradle-refresh-dependencies == 'true' && '--refresh-dependencies' || '' }}
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
 
     - name: Commit CHANGELOG.md file and push
       run: |
+        mv ${{ runner.temp }}/CHANGELOG.md CHANGELOG.md
         git add CHANGELOG.md
         git commit -m "Changelog for version ${{ steps.evaluate-version.outputs.release-version }}"
         git push --follow-tags origin

--- a/actions/java-gradle-release/action.yaml
+++ b/actions/java-gradle-release/action.yaml
@@ -99,7 +99,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
 
     - name: Create changelog # Generate changelog before creating the tag or the tag appears twice in the changelog
-      uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
+      uses: bakdata/ci-templates/actions/changelog-generate@1.70.0
       with:
         github-token: ${{ inputs.github-token }}
         changelog-file: ${{ runner.temp }}/CHANGELOG.md # Use temporary file to not have uncommitted changes

--- a/actions/java-gradle-release/action.yaml
+++ b/actions/java-gradle-release/action.yaml
@@ -103,24 +103,15 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
-    - name: Push release tag
-      run: |
-        git push --tags origin
-      shell: bash
-
     - name: Create changelog
-      run: ./gradlew -Pchangelog.githubRepository=${{ github.event.repository.name }} -Pchangelog.futureVersionTag=${{ steps.evaluate-version.outputs.release-version }} --stacktrace --info generateChangelog ${{ inputs.gradle-refresh-dependencies == 'true' && '--refresh-dependencies' || '' }}
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-      env:
-        GITHUB_USER: ${{ github.repository_owner }}
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-
-    - name: Commit and push CHANGELOG.md file
-      uses: bakdata/ci-templates/actions/commit-and-push@1.50.4
+      uses: bakdata/ci-templates/actions/changelog-generate@1.69.2
       with:
-        commit-message: "Changelog for version ${{ steps.evaluate-version.outputs.release-version }}"
-        github-username: ${{ inputs.github-username }}
-        github-email: ${{ inputs.github-email }}
         github-token: ${{ inputs.github-token }}
-        add-untracked: "true"
+        tag: ${{ steps.evaluate-version.outputs.release-version }}
+
+    - name: Commit CHANGELOG.md file and push
+      run: |
+        git add CHANGELOG.md
+        git commit -m "Changelog for version ${{ steps.evaluate-version.outputs.release-version }}"
+        git push --follow-tags origin
+      shell: bash

--- a/actions/java-gradle-release/action.yaml
+++ b/actions/java-gradle-release/action.yaml
@@ -104,7 +104,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
 
     - name: Create changelog
-      uses: bakdata/ci-templates/actions/changelog-generate@1.69.2
+      uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
       with:
         github-token: ${{ inputs.github-token }}
         tag: ${{ steps.evaluate-version.outputs.release-version }}

--- a/actions/java-gradle-release/action.yaml
+++ b/actions/java-gradle-release/action.yaml
@@ -102,8 +102,8 @@ runs:
       uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
       with:
         github-token: ${{ inputs.github-token }}
-        tag: ${{ steps.evaluate-version.outputs.release-version }}
-        changelog-file: ${{ runner.temp }}/CHANGELOG.md
+        changelog-file: ${{ runner.temp }}/CHANGELOG.md # Use temporary file to not have uncommitted changes
+        additional-cliff-args: --tag ${{ steps.evaluate-version.outputs.release-version }}
 
     - name: Create release
       run: ./gradlew release -x test -Prelease.useAutomaticVersion=true -Prelease.releaseVersion=${{ steps.evaluate-version.outputs.release-version }} -Prelease.disablePushToRemote=true -Prelease.requireBranch=${{ github.event.repository.default_branch }} ${{ inputs.gradle-refresh-dependencies == 'true' && '--refresh-dependencies' || '' }}

--- a/actions/java-gradle-release/action.yaml
+++ b/actions/java-gradle-release/action.yaml
@@ -98,7 +98,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
 
-    - name: Create changelog
+    - name: Create changelog # Generate changelog before creating the tag or the tag appears twice in the changelog
       uses: bakdata/ci-templates/actions/changelog-generate@feature/gradle-release-git-cliff
       with:
         github-token: ${{ inputs.github-token }}

--- a/docs/actions/changelog-generate/README.md
+++ b/docs/actions/changelog-generate/README.md
@@ -86,14 +86,14 @@ steps:
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-| INPUT                 | TYPE   | REQUIRED | DEFAULT          | DESCRIPTION                                         |
-| --------------------- | ------ | -------- | ---------------- | --------------------------------------------------- |
-| additional-cliff-args | string | false    |                  | Additional arguments to the git-cliff binary        |
-| changelog-file        | string | false    | `"CHANGELOG.md"` | Path to the changelog file in the GitHub repository |
-| checkout              | string | false    | `"false"`        | Whether to checkout the repository or not.          |
-| clean                 | string | false    | `"false"`        | Clean the repository before running the action.     |
-| github-token          | string | true     |                  | The GitHub token for committing the changes.        |
-| verbose               | string | false    | `"false"`        | Run git-cliff in verbose mdoe                       |
+| INPUT                 | TYPE   | REQUIRED | DEFAULT   | DESCRIPTION                                         |
+| --------------------- | ------ | -------- | --------- | --------------------------------------------------- |
+| additional-cliff-args | string | false    |           | Additional arguments to the git-cliff binary        |
+| changelog-file        | string | false    |           | Path to the changelog file in the GitHub repository |
+| checkout              | string | false    | `"false"` | Whether to checkout the repository or not.          |
+| clean                 | string | false    | `"false"` | Clean the repository before running the action.     |
+| github-token          | string | true     |           | The GitHub token for committing the changes.        |
+| verbose               | string | false    | `"false"` | Run git-cliff in verbose mdoe                       |
 
 <!-- AUTO-DOC-INPUT:END -->
 

--- a/docs/actions/changelog-generate/README.md
+++ b/docs/actions/changelog-generate/README.md
@@ -93,7 +93,6 @@ steps:
 | checkout              | string | false    | `"false"`        | Whether to checkout the repository or not.          |
 | clean                 | string | false    | `"false"`        | Clean the repository before running the action.     |
 | github-token          | string | true     |                  | The GitHub token for committing the changes.        |
-| tag                   | string | true     |                  | Version after bump                                  |
 | verbose               | string | false    | `"false"`        | Run git-cliff in verbose mdoe                       |
 
 <!-- AUTO-DOC-INPUT:END -->
@@ -102,10 +101,9 @@ steps:
 
 <!-- AUTO-DOC-OUTPUT:START - Do not remove or modify this section -->
 
-| OUTPUT           | TYPE   | DESCRIPTION                |
-| ---------------- | ------ | -------------------------- |
-| merged-changelog | string | All changelogs combined.   |
-| single-changelog | string | Only the latest changelog. |
+| OUTPUT    | TYPE   | DESCRIPTION       |
+| --------- | ------ | ----------------- |
+| changelog | string | Changelog output. |
 
 <!-- AUTO-DOC-OUTPUT:END -->
 

--- a/docs/actions/java-gradle-release-github/README.md
+++ b/docs/actions/java-gradle-release-github/README.md
@@ -23,16 +23,9 @@ steps:
 
 <!-- AUTO-DOC-INPUT:START - Do not remove or modify this section -->
 
-| INPUT                       | TYPE   | REQUIRED | DEFAULT                                                                                                 | DESCRIPTION                                                                                                                                                         |
-| --------------------------- | ------ | -------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| github-token                | string | true     |                                                                                                         | GitHub token for requesting changes from API.                                                                                                                       |
-| gradle-cache                | string | false    | `"true"`                                                                                                | Whether Gradle caching is enabled or not. (Default is true)                                                                                                         |
-| gradle-cache-read-only      | string | false    | `"${{ github.event.repository != null && github.ref_name != github.event.repository.default_branch }}"` | Whether Gradle caching should be read-only. By default this value is 'false' for workflows on the GitHub default branch and 'true' for workflows on other branches. |
-| gradle-refresh-dependencies | string | false    | `"false"`                                                                                               | Whether Gradle should refresh dependencies. (Default is false)                                                                                                      |
-| gradle-version              | string | false    | `"wrapper"`                                                                                             | Gradle version to be installed. (Default is wrapper)                                                                                                                |
-| java-distribution           | string | false    | `"microsoft"`                                                                                           | Java distribution to be installed. (Default is microsoft)                                                                                                           |
-| java-version                | string | false    | `"11"`                                                                                                  | Java version to be installed. (Default is 11)                                                                                                                       |
-| working-directory           | string | false    | `"."`                                                                                                   | Working directory of your Gradle artifacts. (Default is .)                                                                                                          |
+| INPUT        | TYPE   | REQUIRED | DEFAULT | DESCRIPTION                                   |
+| ------------ | ------ | -------- | ------- | --------------------------------------------- |
+| github-token | string | true     |         | GitHub token for requesting changes from API. |
 
 <!-- AUTO-DOC-INPUT:END -->
 


### PR DESCRIPTION
- Refactored git-cliff action so it only runs a single time. Parameters are more flexible
- Gradle changelogs are generated using git-cliff
- pre-commit runs on Windows
- bot commits are filtered from changelogs