### PR TITLE
refactor(uv-release): checkout before setup uv

### DIFF
--- a/.github/workflows/python-uv-release.yaml
+++ b/.github/workflows/python-uv-release.yaml
@@ -73,18 +73,18 @@ jobs:
       old-version: ${{ steps.bump-version.outputs.old-version }}
 
     steps:
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          python-version: ${{ inputs.python-version }}
-          version: ${{ inputs.uv-version }}
-
       - name: Check out repository
         uses: bakdata/ci-templates/actions/checkout@1.81.1
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false # required for pushing to protected branch later
           fetch-depth: 0 # required for changelog generation
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ inputs.python-version }}
+          version: ${{ inputs.uv-version }}
 
       - name: Get latest tag
         id: latest-tag


### PR DESCRIPTION
otherwise there are the following warnings:

- No file matched to `[**/uv.lock,**/requirements*.txt]`. The cache will never get invalidated. Make sure you have checked out the target repository and configured the `cache-dependency-glob` input correctly.
- Empty workdir detected. This may cause unexpected behavior. You can enable `ignore-empty-workdir` to mute this warning.