### PR TITLE
fix(bump-version): pin bump-my-version dependency

### DIFF
--- a/actions/bump-version/action.yaml
+++ b/actions/bump-version/action.yaml
@@ -31,7 +31,7 @@ runs:
   steps:
     - name: Set up bump-my-version
       run: |
-        pipx install bump-my-version
+        pipx install bump-my-version==1.3.0
       shell: bash
 
     - name: Bump version


### PR DESCRIPTION
avoids breaking change in bump-my-version 1.4.0

example:
```
╭─ Error ──────────────────────────────────────────────────────────────────────╮
│ Hook 'cd backend && uv lock --no-refresh --upgrade-package=my-package'       │
│ contains shell syntax (pipes, redirects, or variable expansion). Set         │
│ `allow_shell_hooks = true` in your configuration to enable shell execution,  │
│ or rewrite the hook as an explicit command without shell syntax.             │
╰──────────────────────────────────────────────────────────────────────────────╯
```